### PR TITLE
chore: bump solang

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1161,9 +1161,9 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "solang-parser"
-version = "0.2.1"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e9653f278d9531b60f042c29732bb835d519943f4167b1e5684c7e820dd9fec"
+checksum = "ff87dae6cdccacdbf3b19e99b271083556e808de0f59c74a01482f64fdbc61fc"
 dependencies = [
  "itertools",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 petgraph = "0.6.2"
-solang-parser = { version = "0.2.1", features = ["pt-serde"] }
+solang-parser = { version = "0.2.3", features = ["pt-serde"] }
 ethers-core = "*"
 ariadne = "0.2.0"
 shared = { path = "./shared" }

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -634,7 +634,7 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
         // println!("ctx: {}, {:?}", ctx.underlying(self).path, expr);
         match expr {
             // literals
-            NumberLiteral(loc, int, exp) => self.number_literal(ctx, *loc, int, exp, false),
+            NumberLiteral(loc, int, exp, _unit) => self.number_literal(ctx, *loc, int, exp, false),
             AddressLiteral(loc, addr) => self.address_literal(ctx, *loc, addr),
             StringLiteral(lits) => ExprRet::Multi(
                 lits.iter()
@@ -642,12 +642,14 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
                     .collect(),
             ),
             BoolLiteral(loc, b) => self.bool_literal(ctx, *loc, *b),
-            HexNumberLiteral(loc, b) => self.hex_num_literal(ctx, *loc, b, false),
+            HexNumberLiteral(loc, b, _unit) => self.hex_num_literal(ctx, *loc, b, false),
             HexLiteral(hexes) => self.hex_literals(ctx, hexes),
-            RationalNumberLiteral(_, _, _, _) => todo!("Rational literal"),
-            UnaryMinus(_loc, expr) => match &**expr {
-                NumberLiteral(loc, int, exp) => self.number_literal(ctx, *loc, int, exp, true),
-                HexNumberLiteral(loc, b) => self.hex_num_literal(ctx, *loc, b, true),
+            RationalNumberLiteral(_, _, _, _, _) => todo!("Rational literal"),
+            Negate(_loc, expr) => match &**expr {
+                NumberLiteral(loc, int, exp, _unit) => {
+                    self.number_literal(ctx, *loc, int, exp, true)
+                }
+                HexNumberLiteral(loc, b, _unit) => self.hex_num_literal(ctx, *loc, b, true),
                 e => todo!("UnaryMinus unexpected rhs: {e:?}"),
             },
             UnaryPlus(_loc, e) => todo!("UnaryPlus unexpected rhs: {e:?}"),
@@ -814,7 +816,7 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
                                 .iter()
                                 .map(|expr| {
                                     match expr {
-                                        UnaryMinus(_, expr) => {
+                                        Negate(_, expr) => {
                                             // negative number potentially
                                             matches!(**expr, NumberLiteral(..) | HexLiteral(..))
                                         }
@@ -901,7 +903,6 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
                 }
             }
             Parenthesis(_loc, expr) => self.parse_ctx_expr(expr, ctx),
-            Unit(_, _, _) => todo!("Unit"),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@ impl AnalyzerLike for Analyzer {
                 // }
                 0.into()
             }
-            NumberLiteral(_loc, int, exp) => {
+            NumberLiteral(_loc, int, exp, _unit) => {
                 let int = U256::from_dec_str(int).unwrap();
                 let val = if !exp.is_empty() {
                     let exp = U256::from_dec_str(exp).unwrap();


### PR DESCRIPTION
Bump solang to support newer features like named keys in mappings. Prior to this change PR panics on named mapping keys due to unknown identifers. Relevant solang commits:
- https://github.com/hyperledger/solang/commit/b0e97c43e2c06995599c2f8ab9a13f9d6d4718b2#diff-f405bd2c266e394a31b0a0cae986996dfd75f274cb2c468243e37d47eef640df
- https://github.com/hyperledger/solang/commit/28da91132fba931acdc8a89aa9d644ea21f4edb4#diff-f405bd2c266e394a31b0a0cae986996dfd75f274cb2c468243e37d47eef640df