### PR TITLE
feat: support remappings and relative imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,24 +3,6 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aes"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
- "opaque-debug",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,12 +10,6 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "anyhow"
-version = "1.0.70"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "ariadne"
@@ -96,12 +72,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
-name = "base64"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
-
-[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,27 +112,12 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
-
-[[package]]
-name = "bumpalo"
-version = "3.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
@@ -186,34 +141,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "bzip2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
-dependencies = [
- "bzip2-sys",
- "libc",
-]
-
-[[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -232,57 +163,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "cipher"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "clap"
-version = "3.2.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
-dependencies = [
- "atty",
- "bitflags",
- "clap_derive 3.2.18",
- "clap_lex 0.2.4",
- "indexmap",
- "once_cell",
- "strsim",
- "termcolor",
- "textwrap",
-]
-
-[[package]]
 name = "clap"
 version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
- "clap_derive 4.1.8",
- "clap_lex 0.3.2",
+ "clap_derive",
+ "clap_lex",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
-]
-
-[[package]]
-name = "clap_derive"
-version = "3.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -300,15 +192,6 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "clap_lex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
@@ -321,36 +204,9 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "ariadne",
- "clap 4.1.8",
+ "clap",
  "pyrometer",
  "shared",
-]
-
-[[package]]
-name = "console"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "regex",
- "terminal_size",
- "unicode-width",
- "winapi",
-]
-
-[[package]]
-name = "console"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
-dependencies = [
- "encode_unicode",
- "lazy_static",
- "libc",
- "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -360,70 +216,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
-dependencies = [
- "cfg-if",
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
-dependencies = [
- "autocfg",
- "cfg-if",
- "crossbeam-utils",
- "memoffset",
- "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -476,18 +274,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dialoguer"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
-dependencies = [
- "console 0.14.1",
- "lazy_static",
- "tempfile",
- "zeroize",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,20 +281,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.3",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -533,12 +310,6 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "ecdsa"
@@ -567,7 +338,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest 0.10.6",
+ "digest",
  "ff",
  "generic-array",
  "group",
@@ -584,21 +355,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
-]
-
-[[package]]
-name = "encode_unicode"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
-
-[[package]]
-name = "encoding_rs"
-version = "0.8.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -697,47 +453,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ethers-solc"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe9c0a6d296c57191e5f8a613a3b5e816812c28f4a28d6178a17c21db903d77"
-dependencies = [
- "cfg-if",
- "dunce",
- "ethers-core",
- "getrandom",
- "glob",
- "hex",
- "home",
- "md-5",
- "num_cpus",
- "once_cell",
- "path-slash",
- "rayon",
- "regex",
- "semver",
- "serde",
- "serde_json",
- "solang-parser 0.1.18",
- "svm-rs",
- "thiserror",
- "tiny-keccak",
- "tokio",
- "tracing",
- "walkdir",
- "yansi",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -766,93 +481,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "flate2"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
-
-[[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "form_urlencoded"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
-dependencies = [
- "percent-encoding",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
-
-[[package]]
-name = "futures-channel"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
-dependencies = [
- "futures-core",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
-
-[[package]]
-name = "futures-io"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
-
-[[package]]
-name = "futures-task"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
-
-[[package]]
-name = "futures-util"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
-dependencies = [
- "futures-core",
- "futures-io",
- "futures-task",
- "memchr",
- "pin-project-lite",
- "pin-utils",
- "slab",
-]
 
 [[package]]
 name = "generic-array"
@@ -871,17 +503,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
-
-[[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -892,25 +516,6 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -936,15 +541,6 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -961,97 +557,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
-]
-
-[[package]]
-name = "home"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "http"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
-dependencies = [
- "bytes",
- "http",
- "pin-project-lite",
-]
-
-[[package]]
-name = "httparse"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
-
-[[package]]
-name = "httpdate"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "hyper"
-version = "0.14.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper-rustls"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
-dependencies = [
- "http",
- "hyper",
- "rustls",
- "tokio",
- "tokio-rustls",
-]
-
-[[package]]
-name = "idna"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "digest",
 ]
 
 [[package]]
@@ -1103,27 +609,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indicatif"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
-dependencies = [
- "console 0.15.5",
- "lazy_static",
- "number_prefix",
- "regex",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,12 +617,6 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
-
-[[package]]
-name = "ipnet"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -1167,24 +646,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
-name = "jobserver"
-version = "0.1.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "js-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,7 +654,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.6",
+ "sha2",
  "sha3",
 ]
 
@@ -1276,55 +737,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "md-5"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
-dependencies = [
- "digest 0.10.6",
-]
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
-name = "memoffset"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
-dependencies = [
- "libc",
- "log",
- "wasi",
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -1352,32 +768,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
-dependencies = [
- "hermit-abi 0.2.6",
- "libc",
-]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
-
-[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open-fastrlp"
@@ -1460,41 +854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "password-hash"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
-dependencies = [
- "base64ct",
- "rand_core",
- "subtle",
-]
-
-[[package]]
-name = "path-slash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
-
-[[package]]
-name = "pbkdf2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
-dependencies = [
- "digest 0.10.6",
- "hmac",
- "password-hash",
- "sha2 0.10.6",
-]
-
-[[package]]
-name = "percent-encoding"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
-
-[[package]]
 name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1506,33 +865,12 @@ dependencies = [
 
 [[package]]
 name = "phf"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_macros 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
- "phf_macros 0.11.1",
+ "phf_macros",
  "phf_shared 0.11.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
-dependencies = [
- "phf_shared 0.10.0",
- "rand",
 ]
 
 [[package]]
@@ -1547,25 +885,11 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
-dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
- "proc-macro-hack",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_macros"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
 dependencies = [
- "phf_generator 0.11.1",
+ "phf_generator",
  "phf_shared 0.11.1",
  "proc-macro2",
  "quote",
@@ -1597,18 +921,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1617,12 +929,6 @@ dependencies = [
  "der",
  "spki",
 ]
-
-[[package]]
-name = "pkg-config"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -1686,12 +992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.20+deprecated"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,11 +1006,10 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "ethers-core",
- "ethers-solc",
  "hex",
  "petgraph",
  "shared",
- "solang-parser 0.2.3",
+ "solang-parser",
 ]
 
 [[package]]
@@ -1759,28 +1058,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rayon"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-utils",
- "num_cpus",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1818,45 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "reqwest"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
-dependencies = [
- "base64",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-rustls",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,21 +1103,6 @@ dependencies = [
  "crypto-bigint",
  "hmac",
  "zeroize",
-]
-
-[[package]]
-name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin",
- "untrusted",
- "web-sys",
- "winapi",
 ]
 
 [[package]]
@@ -1924,27 +1147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls"
-version = "0.20.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
-dependencies = [
- "log",
- "ring",
- "sct",
- "webpki",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
-dependencies = [
- "base64",
-]
-
-[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1955,15 +1157,6 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "scale-info"
@@ -1996,16 +1189,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2017,15 +1200,6 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2060,42 +1234,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "sha1"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2103,7 +1241,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -2112,7 +1250,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest 0.10.6",
+ "digest",
  "keccak",
 ]
 
@@ -2124,16 +1262,7 @@ dependencies = [
  "hex",
  "lazy_static",
  "petgraph",
- "solang-parser 0.2.3",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
-dependencies = [
- "libc",
+ "solang-parser",
 ]
 
 [[package]]
@@ -2142,7 +1271,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest 0.10.6",
+ "digest",
  "rand_core",
 ]
 
@@ -2153,42 +1282,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
-name = "slab"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "socket2"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "solang-parser"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac8ac4bfef383f368bd9bb045107a501cd9cd0b64ad1983e1b7e839d6a44ecad"
-dependencies = [
- "itertools",
- "lalrpop",
- "lalrpop-util",
- "phf 0.10.1",
- "unicode-xid",
-]
 
 [[package]]
 name = "solang-parser"
@@ -2199,16 +1296,10 @@ dependencies = [
  "itertools",
  "lalrpop",
  "lalrpop-util",
- "phf 0.11.1",
+ "phf",
  "serde",
  "unicode-xid",
 ]
-
-[[package]]
-name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -2274,37 +1365,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
-name = "svm-rs"
-version = "0.2.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
-dependencies = [
- "anyhow",
- "cfg-if",
- "clap 3.2.23",
- "console 0.14.1",
- "dialoguer",
- "fs2",
- "hex",
- "home",
- "indicatif",
- "itertools",
- "once_cell",
- "rand",
- "reqwest",
- "semver",
- "serde",
- "serde_json",
- "sha2 0.9.9",
- "tempfile",
- "thiserror",
- "tokio",
- "tracing",
- "url",
- "zip",
-]
-
-[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,19 +1380,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "tempfile"
-version = "3.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall",
- "rustix",
- "windows-sys 0.42.0",
-]
 
 [[package]]
 name = "term"
@@ -2355,22 +1402,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "textwrap"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
-
-[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,99 +1422,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
-dependencies = [
- "serde",
- "time-core",
-]
-
-[[package]]
-name = "time-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
-name = "tokio"
-version = "1.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
-dependencies = [
- "autocfg",
- "bytes",
- "libc",
- "memchr",
- "mio",
- "num_cpus",
- "parking_lot",
- "pin-project-lite",
- "signal-hook-registry",
- "socket2",
- "tokio-macros",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
-dependencies = [
- "rustls",
- "tokio",
- "webpki",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2494,50 +1438,6 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
-
-[[package]]
-name = "tower-service"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
-
-[[package]]
-name = "tracing"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
-dependencies = [
- "cfg-if",
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "try-lock"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -2558,25 +1458,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-width"
@@ -2591,148 +1476,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
-name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "url"
-version = "2.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
-dependencies = [
- "form_urlencoded",
- "idna",
- "percent-encoding",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
-name = "walkdir"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
-name = "want"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
-dependencies = [
- "log",
- "try-lock",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
-dependencies = [
- "bumpalo",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-futures"
-version = "0.4.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.84"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
-
-[[package]]
-name = "web-sys"
-version = "0.3.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
-dependencies = [
- "webpki",
-]
 
 [[package]]
 name = "winapi"
@@ -2847,15 +1600,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
-name = "winreg"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,53 +1619,3 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
-
-[[package]]
-name = "zip"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
-dependencies = [
- "aes",
- "byteorder",
- "bzip2",
- "constant_time_eq",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
- "hmac",
- "pbkdf2",
- "sha1",
- "time",
- "zstd",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.7+zstd.1.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,24 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "aes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8b47f52ea9bae42228d07ec09eb676433d7c4ed1ebdf0f1d1c29ed446f1ab8"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+ "opaque-debug",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,6 +28,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "anyhow"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de8ce5e0f9f8d88245311066a578d72b7af3e7088f32783804676302df237e4"
 
 [[package]]
 name = "ariadne"
@@ -72,6 +96,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "base64ct"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -112,12 +142,27 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
  "generic-array",
 ]
+
+[[package]]
+name = "bumpalo"
+version = "3.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d261e256854913907f67ed06efbc3338dfe6179796deefc1ff763fc1aee5535"
 
 [[package]]
 name = "byte-slice-cast"
@@ -141,10 +186,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -163,18 +232,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "cipher"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ee52072ec15386f770805afd189a01c8841be8696bed250fa2f13c4c0d6dfb7"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive 3.2.18",
+ "clap_lex 0.2.4",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
 name = "clap"
 version = "4.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d7ae14b20b94cb02149ed21a86c423859cbe18dc7ed69845cace50e52b40a5"
 dependencies = [
  "bitflags",
- "clap_derive",
- "clap_lex",
+ "clap_derive 4.1.8",
+ "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
  "strsim",
  "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -192,6 +300,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
+name = "clap_lex"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350b9cf31731f9957399229e9b2adc51eeabdfbe9d71d9a0552275fd12710d09"
@@ -204,9 +321,36 @@ name = "cli"
 version = "0.1.0"
 dependencies = [
  "ariadne",
- "clap",
+ "clap 4.1.8",
  "pyrometer",
  "shared",
+]
+
+[[package]]
+name = "console"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3993e6445baa160675931ec041a5e03ca84b9c6e32a056150d3aa2bdda0a1f45"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
+name = "console"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d79fbe8970a77e3e34151cc13d3b3e248aa0faaecb9f6091fa07ebefe5ad60"
+dependencies = [
+ "encode_unicode",
+ "lazy_static",
+ "libc",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -216,12 +360,70 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2b3e8478797446514c91ef04bafcb59faba183e621ad488df88983cc14128c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46bd5f3f85273295a9d14aedfb86f6aadbff6d8f5295c4a9edb08e819dcf5695"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -274,6 +476,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9dd058f8b65922819fabb4a41e7d1964e56344042c26efbccd465202c23fa0c"
+dependencies = [
+ "console 0.14.1",
+ "lazy_static",
+ "tempfile",
+ "zeroize",
+]
+
+[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,11 +495,20 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.3",
  "crypto-common",
  "subtle",
 ]
@@ -310,6 +533,12 @@ dependencies = [
  "redox_users",
  "winapi",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd4b30a6560bbd9b4620f4de34c3f14f60848e58a9b7216801afcb4c7b31c3c"
 
 [[package]]
 name = "ecdsa"
@@ -338,7 +567,7 @@ dependencies = [
  "base16ct",
  "crypto-bigint",
  "der",
- "digest",
+ "digest 0.10.6",
  "ff",
  "generic-array",
  "group",
@@ -355,6 +584,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -453,6 +697,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethers-solc"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbe9c0a6d296c57191e5f8a613a3b5e816812c28f4a28d6178a17c21db903d77"
+dependencies = [
+ "cfg-if",
+ "dunce",
+ "ethers-core",
+ "getrandom",
+ "glob",
+ "hex",
+ "home",
+ "md-5",
+ "num_cpus",
+ "once_cell",
+ "path-slash",
+ "rayon",
+ "regex",
+ "semver",
+ "serde",
+ "serde_json",
+ "solang-parser 0.1.18",
+ "svm-rs",
+ "thiserror",
+ "tiny-keccak",
+ "tokio",
+ "tracing",
+ "walkdir",
+ "yansi",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,10 +766,93 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "flate2"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8a2db397cb1c8772f31494cb8917e48cd1e64f0fa7efac59fbd741a0a8ce841"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "164713a5a0dcc3e7b4b1ed7d3b433cabc18025386f9339346e8daf15963cf7ac"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86d7a0c1aa76363dac491de0ee99faf6941128376f1cf96f07db7603b7de69dd"
+
+[[package]]
+name = "futures-io"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec93083a4aecafb2a80a885c9de1f0ccae9dbd32c2bb54b0c3a65690e0b8d2f2"
+
+[[package]]
+name = "futures-task"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd65540d33b37b16542a0438c12e6aeead10d4ac5d05bd3f805b8f35ab592879"
+
+[[package]]
+name = "futures-util"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ef6b17e481503ec85211fed8f39d1970f128935ca1f814cd32ac4a6842e84ab"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -503,9 +871,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "group"
@@ -516,6 +892,25 @@ dependencies = [
  "ff",
  "rand_core",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -541,6 +936,15 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
@@ -557,7 +961,97 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "home"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747309b4b440c06d57b0b25f2aee03ee9b5e5397d288c60e21fc709bb98a7408"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "http"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd6effc99afb63425aff9b05836f029929e345a6148a14b7ecd5ab67af944482"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5f38f16d184e36f2408a55281cd658ecbd3ca05cce6d6510a176eca393e26d1"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
 ]
 
 [[package]]
@@ -609,6 +1103,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console 0.15.5",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +1132,12 @@ dependencies = [
  "libc",
  "windows-sys 0.45.0",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
 
 [[package]]
 name = "is-terminal"
@@ -646,6 +1167,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
+name = "jobserver"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "936cfd212a0155903bcbc060e316fb6cc7cbf2e1907329391ebadc1fe0ce77c2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "k256"
 version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,7 +1193,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "sha2 0.10.6",
  "sha3",
 ]
 
@@ -737,10 +1276,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6365506850d44bff6e2fbcb5176cf63650e48bd45ef2fe2665ae1570e0f4b9ca"
+dependencies = [
+ "digest 0.10.6",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9d9a46eff5b4ff64b45a9e316a6d1e0bc719ef429cbec4dc630684212bfdf9"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.45.0",
+]
 
 [[package]]
 name = "new_debug_unreachable"
@@ -768,10 +1352,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+dependencies = [
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
+
+[[package]]
 name = "once_cell"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "open-fastrlp"
@@ -854,6 +1460,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+ "hmac",
+ "password-hash",
+ "sha2 0.10.6",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+
+[[package]]
 name = "petgraph"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -865,12 +1506,33 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
+dependencies = [
+ "phf_macros 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "phf"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "928c6535de93548188ef63bb7c4036bd415cd8f36ad25af44b9789b2ee72a48c"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.11.1",
  "phf_shared 0.11.1",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+dependencies = [
+ "phf_shared 0.10.0",
+ "rand",
 ]
 
 [[package]]
@@ -885,11 +1547,25 @@ dependencies = [
 
 [[package]]
 name = "phf_macros"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fdf3184dd560f160dd73922bea2d5cd6e8f064bf4b13110abd81b03697b4e0"
+dependencies = [
+ "phf_generator 0.10.0",
+ "phf_shared 0.10.0",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_macros"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92aacdc5f16768709a569e913f7451034034178b05bdc8acda226659a3dccc66"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.11.1",
  "phf_shared 0.11.1",
  "proc-macro2",
  "quote",
@@ -921,6 +1597,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs8"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +1617,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
@@ -992,6 +1686,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-hack"
+version = "0.5.20+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,10 +1706,11 @@ version = "0.1.0"
 dependencies = [
  "ariadne",
  "ethers-core",
+ "ethers-solc",
  "hex",
  "petgraph",
  "shared",
- "solang-parser",
+ "solang-parser 0.2.3",
 ]
 
 [[package]]
@@ -1058,6 +1759,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2df5196e37bcc87abebc0053e20787d73847bb33134a69841207dd0a47f03b"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b8f95bd6966f5c87776639160a66bd8ab9895d9d4ab01ddba9fc60661aebe8d"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1095,6 +1818,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "reqwest"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,6 +1865,21 @@ dependencies = [
  "crypto-bigint",
  "hmac",
  "zeroize",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -1147,6 +1924,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1955,15 @@ name = "ryu"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scale-info"
@@ -1189,6 +1996,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "sec1"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1200,6 +2017,15 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1234,6 +2060,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
+]
+
+[[package]]
+name = "sha2"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
+dependencies = [
+ "block-buffer 0.9.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.9.0",
+ "opaque-debug",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,7 +2103,7 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -1250,7 +2112,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "digest",
+ "digest 0.10.6",
  "keccak",
 ]
 
@@ -1262,7 +2124,16 @@ dependencies = [
  "hex",
  "lazy_static",
  "petgraph",
- "solang-parser",
+ "solang-parser 0.2.3",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1271,7 +2142,7 @@ version = "1.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 dependencies = [
- "digest",
+ "digest 0.10.6",
  "rand_core",
 ]
 
@@ -1282,10 +2153,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
 
 [[package]]
+name = "slab"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6528351c9bc8ab22353f9d776db39a20288e8d6c37ef8cfe3317cf875eecfc2d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+
+[[package]]
+name = "socket2"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "solang-parser"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac8ac4bfef383f368bd9bb045107a501cd9cd0b64ad1983e1b7e839d6a44ecad"
+dependencies = [
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "phf 0.10.1",
+ "unicode-xid",
+]
 
 [[package]]
 name = "solang-parser"
@@ -1296,10 +2199,16 @@ dependencies = [
  "itertools",
  "lalrpop",
  "lalrpop-util",
- "phf",
+ "phf 0.11.1",
  "serde",
  "unicode-xid",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "spki"
@@ -1365,6 +2274,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
+name = "svm-rs"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01afefe60c02f4a2271fb15d1965c37856712cebb338330b06649d12afec42df"
+dependencies = [
+ "anyhow",
+ "cfg-if",
+ "clap 3.2.23",
+ "console 0.14.1",
+ "dialoguer",
+ "fs2",
+ "hex",
+ "home",
+ "indicatif",
+ "itertools",
+ "once_cell",
+ "rand",
+ "reqwest",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.9.9",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "url",
+ "zip",
+]
+
+[[package]]
 name = "syn"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1380,6 +2320,19 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tempfile"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "redox_syscall",
+ "rustix",
+ "windows-sys 0.42.0",
+]
 
 [[package]]
 name = "term"
@@ -1402,6 +2355,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
+
+[[package]]
 name = "thiserror"
 version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1422,12 +2391,99 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
+dependencies = [
+ "serde",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e153e1f1acaef8acc537e68b44906d2db6436e2b35ac2c6b42640fff91f00fd"
+
+[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
+]
+
+[[package]]
+name = "tinyvec"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "tokio"
+version = "1.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03201d01c3c27a29c8a5cee5b55a93ddae1ccf6f08f65365c2c918f8c1b76f64"
+dependencies = [
+ "autocfg",
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "parking_lot",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "socket2",
+ "tokio-macros",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1438,6 +2494,50 @@ checksum = "1333c76748e868a4d9d1017b5ab53171dfd095f70c712fdb4653a406547f598f"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "tower-service"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
+
+[[package]]
+name = "tracing"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+dependencies = [
+ "cfg-if",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "typenum"
@@ -1458,10 +2558,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d502c968c6a838ead8e69b2ee18ec708802f99db92a0d156705ec9ef801993b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"
@@ -1476,16 +2591,148 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "url"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
+name = "walkdir"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f219e0d211ba40266969f6dbdd90636da12f75bee4fc9d6c23d1260dadb51454"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.84"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
 
 [[package]]
 name = "winapi"
@@ -1600,6 +2847,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "wyz"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1619,3 +2875,53 @@ name = "zeroize"
 version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
+
+[[package]]
+name = "zip"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.7+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2021"
 petgraph = "0.6.2"
 solang-parser = { version = "0.2.3", features = ["pt-serde"] }
 ethers-core = "*"
-ethers-solc = "*"
 ariadne = "0.2.0"
 shared = { path = "./shared" }
 hex = "0.4.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 petgraph = "0.6.2"
 solang-parser = { version = "0.2.3", features = ["pt-serde"] }
 ethers-core = "*"
+ethers-solc = "*"
 ariadne = "0.2.0"
 shared = { path = "./shared" }
 hex = "0.4.3"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,7 @@ use std::process::Command;
 use shared::nodes::FunctionNode;
 
 use shared::Edge;
-use std::env::{temp_dir, self};
+use std::env::{self, temp_dir};
 use std::fs;
 
 #[derive(Parser, Debug)]
@@ -117,7 +117,10 @@ fn main() {
 
     let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
 
-    let mut analyzer = Analyzer { root: env::current_dir().unwrap(), ..Default::default() };
+    let mut analyzer = Analyzer {
+        root: env::current_dir().unwrap(),
+        ..Default::default()
+    };
     if args.remappings.is_some() {
         let remappings = args.remappings.unwrap();
         analyzer.set_remappings_and_root(remappings);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -117,10 +117,10 @@ fn main() {
 
     let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
 
-    let mut analyzer = Analyzer::default();
-    analyzer.root = env::current_dir().unwrap();
+    let mut analyzer = Analyzer { root: env::current_dir().unwrap(), ..Default::default() };
     if args.remappings.is_some() {
-        analyzer.set_remappings(args.remappings.unwrap());
+        let remappings = args.remappings.unwrap();
+        analyzer.set_remappings_and_root(remappings);
     }
     let t0 = std::time::Instant::now();
     let (maybe_entry, mut all_sources) = analyzer.parse(&sol, &PathBuf::from(args.path.clone()));

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -24,7 +24,7 @@ use std::process::Command;
 use shared::nodes::FunctionNode;
 
 use shared::Edge;
-use std::env::temp_dir;
+use std::env::{temp_dir, self};
 use std::fs;
 
 #[derive(Parser, Debug)]
@@ -118,6 +118,7 @@ fn main() {
     let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
 
     let mut analyzer = Analyzer::default();
+    analyzer.root = env::current_dir().unwrap();
     if args.remappings.is_some() {
         analyzer.set_remappings(args.remappings.unwrap());
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -18,6 +18,7 @@ use shared::{
 };
 use std::collections::{BTreeMap, HashMap};
 use std::io::Write;
+use std::path::PathBuf;
 use std::process::Command;
 
 use shared::nodes::FunctionNode;
@@ -31,6 +32,8 @@ use std::fs;
 struct Args {
     #[clap(value_hint = ValueHint::FilePath, value_name = "PATH")]
     pub path: String,
+    #[clap(long, short)]
+    pub remappings: Option<String>,
     #[clap(long, short)]
     pub contracts: Vec<String>,
     #[clap(long, short)]
@@ -115,8 +118,11 @@ fn main() {
     let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
 
     let mut analyzer = Analyzer::default();
+    if args.remappings.is_some() {
+        analyzer.set_remappings(args.remappings.unwrap());
+    }
     let t0 = std::time::Instant::now();
-    let (maybe_entry, mut all_sources) = analyzer.parse(&sol);
+    let (maybe_entry, mut all_sources) = analyzer.parse(&sol, &PathBuf::from(args.path.clone()));
     let _parse_time = t0.elapsed().as_millis();
     all_sources.push((maybe_entry, args.path, sol, 0));
     let entry = maybe_entry.unwrap();

--- a/shared/src/analyzer.rs
+++ b/shared/src/analyzer.rs
@@ -114,8 +114,8 @@ pub trait GraphLike {
                 ],
                 &|_graph, edge_ref| {
                     match edge_ref.weight() {
-                        Edge::Context(edge) => format!("label = \"{:?}\"", edge),
-                        e => format!("label = \"{:?}\"", e),
+                        Edge::Context(edge) => format!("label = \"{edge:?}\""),
+                        e => format!("label = \"{e:?}\""),
                     }
                 },
                 &|_graph, (idx, node_ref)| {
@@ -189,8 +189,8 @@ pub trait GraphLike {
                 ],
                 &|_graph, edge_ref| {
                     match edge_ref.weight() {
-                        Edge::Context(edge) => format!("label = \"{:?}\"", edge),
-                        e => format!("label = \"{:?}\"", e),
+                        Edge::Context(edge) => format!("label = \"{edge:?}\""),
+                        e => format!("label = \"{e:?}\""),
                     }
                 },
                 &|_graph, (idx, node_ref)| {
@@ -272,8 +272,8 @@ pub trait GraphLike {
                 ],
                 &|_graph, edge_ref| {
                     match edge_ref.weight() {
-                        Edge::Context(edge) => format!("label = \"{:?}\"", edge),
-                        e => format!("label = \"{:?}\"", e),
+                        Edge::Context(edge) => format!("label = \"{edge:?}\""),
+                        e => format!("label = \"{e:?}\""),
                     }
                 },
                 &|_graph, (idx, node_ref)| {

--- a/shared/src/context/mod.rs
+++ b/shared/src/context/mod.rs
@@ -280,9 +280,7 @@ impl ContextNode {
     pub fn underlying_mut<'a>(&self, analyzer: &'a mut impl GraphLike) -> &'a mut Context {
         match analyzer.node_mut(*self) {
             Node::Context(c) => c,
-            e => panic!(
-                "Node type confusion: expected node to be Context but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Context but it was: {e:?}"),
         }
     }
 
@@ -290,9 +288,7 @@ impl ContextNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Context {
         match analyzer.node(*self) {
             Node::Context(c) => c,
-            e => panic!(
-                "Node type confusion: expected node to be Context but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Context but it was: {e:?}"),
         }
     }
 

--- a/shared/src/context/mod.rs
+++ b/shared/src/context/mod.rs
@@ -1,7 +1,7 @@
 use crate::analyzer::{AnalyzerLike, Search};
 use crate::nodes::FunctionNode;
 use crate::ContractNode;
-use crate::FunctionParamNode;
+
 use crate::GraphLike;
 use crate::{Edge, Node, NodeIdx};
 use petgraph::{visit::EdgeRef, Direction};
@@ -281,8 +281,7 @@ impl ContextNode {
         match analyzer.node_mut(*self) {
             Node::Context(c) => c,
             e => panic!(
-                "Node type confusion: expected node to be Context but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Context but it was: {e:?}"
             ),
         }
     }
@@ -292,8 +291,7 @@ impl ContextNode {
         match analyzer.node(*self) {
             Node::Context(c) => c,
             e => panic!(
-                "Node type confusion: expected node to be Context but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Context but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/context/var.rs
+++ b/shared/src/context/var.rs
@@ -488,10 +488,7 @@ impl ContextVarNode {
         ctx: ContextNode,
         analyzer: &mut (impl GraphLike + AnalyzerLike),
     ) -> Self {
-        let new_underlying = self
-            .underlying(analyzer)
-            .clone()
-            .as_tmp(loc, ctx, analyzer);
+        let new_underlying = self.underlying(analyzer).clone().as_tmp(loc, ctx, analyzer);
         analyzer.add_node(Node::ContextVar(new_underlying)).into()
     }
 
@@ -504,20 +501,12 @@ impl ContextVarNode {
         self.cast_from_ty(to_ty, analyzer);
     }
 
-    pub fn literal_cast_from(
-        &self,
-        other: &Self,
-        analyzer: &mut (impl GraphLike + AnalyzerLike),
-    ) {
+    pub fn literal_cast_from(&self, other: &Self, analyzer: &mut (impl GraphLike + AnalyzerLike)) {
         let to_ty = other.ty(analyzer).clone();
         self.literal_cast_from_ty(to_ty, analyzer);
     }
 
-    pub fn cast_from_ty(
-        &self,
-        to_ty: VarType,
-        analyzer: &mut (impl GraphLike + AnalyzerLike),
-    ) {
+    pub fn cast_from_ty(&self, to_ty: VarType, analyzer: &mut (impl GraphLike + AnalyzerLike)) {
         let from_ty = self.ty(analyzer).clone();
         if !from_ty.ty_eq(&to_ty, analyzer) {
             if let Some(new_ty) = from_ty.try_cast(&to_ty, analyzer) {
@@ -558,10 +547,7 @@ impl ContextVarNode {
         }
     }
 
-    pub fn try_increase_size(
-        &self,
-        analyzer: &mut (impl GraphLike + AnalyzerLike),
-    ) {
+    pub fn try_increase_size(&self, analyzer: &mut (impl GraphLike + AnalyzerLike)) {
         let from_ty = self.ty(analyzer).clone();
         self.cast_from_ty(from_ty.max_size(analyzer), analyzer);
     }
@@ -651,12 +637,7 @@ impl ContextVar {
         let mut new_tmp = self.clone();
         new_tmp.loc = Some(loc);
         new_tmp.is_tmp = true;
-        new_tmp.name = format!(
-            "tmp{}_{}({})",
-            self.name,
-            ctx.new_tmp(analyzer),
-            self.name
-        );
+        new_tmp.name = format!("tmp{}_{}({})", self.name, ctx.new_tmp(analyzer), self.name);
         new_tmp
     }
 

--- a/shared/src/context/var.rs
+++ b/shared/src/context/var.rs
@@ -68,8 +68,7 @@ impl ContextVarNode {
         match analyzer.node(*self) {
             Node::ContextVar(c) => c,
             e => panic!(
-                "Node type confusion: expected node to be ContextVar but it was: {:?}",
-                e
+                "Node type confusion: expected node to be ContextVar but it was: {e:?}"
             ),
         }
     }
@@ -78,8 +77,7 @@ impl ContextVarNode {
         match analyzer.node_mut(*self) {
             Node::ContextVar(c) => c,
             e => panic!(
-                "Node type confusion: expected node to be ContextVar but it was: {:?}",
-                e
+                "Node type confusion: expected node to be ContextVar but it was: {e:?}"
             ),
         }
     }
@@ -698,7 +696,7 @@ impl ContextVar {
                 }
             }
             VarType::Concrete(_) => {}
-            e => panic!("wasnt builtin: {:?}", e),
+            e => panic!("wasnt builtin: {e:?}"),
         }
     }
 
@@ -736,7 +734,7 @@ impl ContextVar {
                 }
             }
             VarType::Concrete(_) => {}
-            e => panic!("wasnt builtin or concrete: {:?}", e),
+            e => panic!("wasnt builtin or concrete: {e:?}"),
         }
     }
 
@@ -756,7 +754,7 @@ impl ContextVar {
                 }
             }
             VarType::Concrete(_) => {}
-            e => panic!("wasnt builtin or concrete: {:?}", e),
+            e => panic!("wasnt builtin or concrete: {e:?}"),
         }
     }
 

--- a/shared/src/context/var.rs
+++ b/shared/src/context/var.rs
@@ -67,18 +67,14 @@ impl ContextVarNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a ContextVar {
         match analyzer.node(*self) {
             Node::ContextVar(c) => c,
-            e => panic!(
-                "Node type confusion: expected node to be ContextVar but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be ContextVar but it was: {e:?}"),
         }
     }
 
     pub fn underlying_mut<'a>(&self, analyzer: &'a mut impl GraphLike) -> &'a mut ContextVar {
         match analyzer.node_mut(*self) {
             Node::ContextVar(c) => c,
-            e => panic!(
-                "Node type confusion: expected node to be ContextVar but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be ContextVar but it was: {e:?}"),
         }
     }
 

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -68,7 +68,7 @@ pub fn as_dot_str(idx: NodeIdx, analyzer: &impl GraphLike) -> String {
         Var(_v) => VarNode::from(idx).as_dot_str(analyzer),
         Ty(_t) => TyNode::from(idx).as_dot_str(analyzer),
         // Concrete(c) => c.as_human_string(),
-        e => format!("{:?}", e),
+        e => format!("{e:?}"),
     }
 }
 

--- a/shared/src/nodes/block.rs
+++ b/shared/src/nodes/block.rs
@@ -15,9 +15,7 @@ impl BlockNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Block {
         match analyzer.node(*self) {
             Node::Block(st) => st,
-            e => panic!(
-                "Node type confusion: expected node to be Msg but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Msg but it was: {e:?}"),
         }
     }
 }

--- a/shared/src/nodes/block.rs
+++ b/shared/src/nodes/block.rs
@@ -16,8 +16,7 @@ impl BlockNode {
         match analyzer.node(*self) {
             Node::Block(st) => st,
             e => panic!(
-                "Node type confusion: expected node to be Msg but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Msg but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/concrete.rs
+++ b/shared/src/nodes/concrete.rs
@@ -11,9 +11,7 @@ impl ConcreteNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Concrete {
         match analyzer.node(*self) {
             Node::Concrete(c) => c,
-            e => panic!(
-                "Node type confusion: expected node to be Concrete but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Concrete but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/concrete.rs
+++ b/shared/src/nodes/concrete.rs
@@ -12,8 +12,7 @@ impl ConcreteNode {
         match analyzer.node(*self) {
             Node::Concrete(c) => c,
             e => panic!(
-                "Node type confusion: expected node to be Concrete but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Concrete but it was: {e:?}"
             ),
         }
     }
@@ -614,7 +613,7 @@ impl Concrete {
                 "0x{}",
                 b.0.iter()
                     .take(*size as usize)
-                    .map(|byte| format!("{:02x}", byte))
+                    .map(|byte| format!("{byte:02x}"))
                     .collect::<Vec<_>>()
                     .join("")
             ),
@@ -646,14 +645,14 @@ impl Concrete {
                         if val < &pow2 {
                             let diff = pow2 - val;
                             if diff < cutoff {
-                                return format!("2**{} - {}", size, diff);
+                                return format!("2**{size} - {diff}");
                             }
                         } else if *val == pow2 {
-                            return format!("2**{}", size);
+                            return format!("2**{size}");
                         } else {
                             let diff = val - pow2;
                             if diff < cutoff {
-                                return format!("2**{} + {}", size, diff);
+                                return format!("2**{size} + {diff}");
                             }
                         }
                     }
@@ -690,14 +689,14 @@ impl Concrete {
                     "0x{}",
                     b.0.iter()
                         .take(*size as usize)
-                        .map(|byte| format!("{:02x}", byte))
+                        .map(|byte| format!("{byte:02x}"))
                         .collect::<Vec<_>>()
                         .join("")
                 )
             }
             Concrete::String(s) => s.to_string(),
             Concrete::Bool(b) => b.to_string(),
-            Concrete::Address(a) => format!("{:?}", a),
+            Concrete::Address(a) => format!("{a:?}"),
             Concrete::DynBytes(a) => {
                 if a.is_empty() {
                     "0x".to_string()

--- a/shared/src/nodes/concrete.rs
+++ b/shared/src/nodes/concrete.rs
@@ -190,23 +190,26 @@ impl Concrete {
 
     pub fn literal_cast(self, builtin: Builtin) -> Option<Self> {
         match self {
-            Concrete::Uint(_, val) => {
-                match builtin {
-                    Builtin::Bytes(size) => {
-                        let mask = if size == 32 {
-                            U256::MAX
-                        } else {
-                            U256::from(2).pow((size as u16 * 8).into()) - 1
-                        };
+            Concrete::Uint(_, val) => match builtin {
+                Builtin::Bytes(size) => {
+                    let mask = if size == 32 {
+                        U256::MAX
+                    } else {
+                        U256::from(2).pow((size as u16 * 8).into()) - 1
+                    };
 
-
-                        let h = H256::from_slice(&(val & mask).0.iter().flat_map(|v| v.to_le_bytes()).collect::<Vec<_>>()[..]);
-                        Some(Concrete::Bytes(size, h))
-                    } 
-                    _ => self.cast(builtin)
+                    let h = H256::from_slice(
+                        &(val & mask)
+                            .0
+                            .iter()
+                            .flat_map(|v| v.to_le_bytes())
+                            .collect::<Vec<_>>()[..],
+                    );
+                    Some(Concrete::Bytes(size, h))
                 }
-            }
-            _ => self.cast(builtin)
+                _ => self.cast(builtin),
+            },
+            _ => self.cast(builtin),
         }
     }
 

--- a/shared/src/nodes/contract_ty.rs
+++ b/shared/src/nodes/contract_ty.rs
@@ -32,8 +32,7 @@ impl ContractNode {
         match analyzer.node(*self) {
             Node::Contract(func) => func,
             e => panic!(
-                "Node type confusion: expected node to be Contract but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Contract but it was: {e:?}"
             ),
         }
     }
@@ -123,7 +122,7 @@ impl Contract {
         con.base.iter().for_each(|base| {
             let inherited_name = &base.name.identifiers[0].name;
             for entry in imports.iter().filter_map(|import| import.0) {
-                println!("{:?}", entry);
+                println!("{entry:?}");
                 for contract in analyzer.search_children(entry, &Edge::Contract).into_iter() {
                     let name = ContractNode::from(contract).name(analyzer);
                     if &name == inherited_name {

--- a/shared/src/nodes/contract_ty.rs
+++ b/shared/src/nodes/contract_ty.rs
@@ -31,9 +31,7 @@ impl ContractNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Contract {
         match analyzer.node(*self) {
             Node::Contract(func) => func,
-            e => panic!(
-                "Node type confusion: expected node to be Contract but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Contract but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/enum_ty.rs
+++ b/shared/src/nodes/enum_ty.rs
@@ -28,9 +28,7 @@ impl EnumNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Enum {
         match analyzer.node(*self) {
             Node::Enum(e) => e,
-            e => panic!(
-                "Node type confusion: expected node to be Contract but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Contract but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/enum_ty.rs
+++ b/shared/src/nodes/enum_ty.rs
@@ -29,8 +29,7 @@ impl EnumNode {
         match analyzer.node(*self) {
             Node::Enum(e) => e,
             e => panic!(
-                "Node type confusion: expected node to be Contract but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Contract but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/err_ty.rs
+++ b/shared/src/nodes/err_ty.rs
@@ -10,8 +10,7 @@ impl ErrorNode {
         match analyzer.node(*self) {
             Node::Error(err) => err,
             e => panic!(
-                "Node type confusion: expected node to be Var but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Var but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/err_ty.rs
+++ b/shared/src/nodes/err_ty.rs
@@ -9,9 +9,7 @@ impl ErrorNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Error {
         match analyzer.node(*self) {
             Node::Error(err) => err,
-            e => panic!(
-                "Node type confusion: expected node to be Var but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Var but it was: {e:?}"),
         }
     }
 }

--- a/shared/src/nodes/func_ty.rs
+++ b/shared/src/nodes/func_ty.rs
@@ -25,9 +25,7 @@ impl FunctionNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Function {
         match analyzer.node(*self) {
             Node::Function(func) => func,
-            e => panic!(
-                "Node type confusion: expected node to be Function but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Function but it was: {e:?}"),
         }
     }
 
@@ -68,9 +66,7 @@ impl FunctionNode {
     pub fn underlying_mut<'a>(&self, analyzer: &'a mut impl GraphLike) -> &'a mut Function {
         match analyzer.node_mut(*self) {
             Node::Function(func) => func,
-            e => panic!(
-                "Node type confusion: expected node to be Function but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Function but it was: {e:?}"),
         }
     }
 
@@ -394,9 +390,7 @@ impl FunctionParamNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a FunctionParam {
         match analyzer.node(*self) {
             Node::FunctionParam(param) => param,
-            e => panic!(
-                "Node type confusion: expected node to be FunctionParam but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be FunctionParam but it was: {e:?}"),
         }
     }
 
@@ -504,9 +498,7 @@ impl FunctionReturnNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a FunctionReturn {
         match analyzer.node(*self) {
             Node::FunctionReturn(ret) => ret,
-            e => panic!(
-                "Node type confusion: expected node to be FunctionParam but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be FunctionParam but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/func_ty.rs
+++ b/shared/src/nodes/func_ty.rs
@@ -26,8 +26,7 @@ impl FunctionNode {
         match analyzer.node(*self) {
             Node::Function(func) => func,
             e => panic!(
-                "Node type confusion: expected node to be Function but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Function but it was: {e:?}"
             ),
         }
     }
@@ -70,8 +69,7 @@ impl FunctionNode {
         match analyzer.node_mut(*self) {
             Node::Function(func) => func,
             e => panic!(
-                "Node type confusion: expected node to be Function but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Function but it was: {e:?}"
             ),
         }
     }
@@ -239,8 +237,8 @@ impl AsDotStr for FunctionNode {
             .attributes
             .iter()
             .map(|attr| match attr {
-                FunctionAttribute::Mutability(inner) => format!("{}", inner),
-                FunctionAttribute::Visibility(inner) => format!("{}", inner),
+                FunctionAttribute::Mutability(inner) => format!("{inner}"),
+                FunctionAttribute::Visibility(inner) => format!("{inner}"),
                 FunctionAttribute::Virtual(_) => "virtual".to_string(),
                 FunctionAttribute::Immutable(_) => "immutable".to_string(),
                 FunctionAttribute::Override(_, _) => "override".to_string(),
@@ -379,7 +377,7 @@ impl AsDotStr for FunctionParamNode {
             "{}{}{}",
             var_ty.as_dot_str(analyzer),
             if let Some(stor) = &self.underlying(analyzer).storage {
-                format!(" {} ", stor)
+                format!(" {stor} ")
             } else {
                 "".to_string()
             },
@@ -397,8 +395,7 @@ impl FunctionParamNode {
         match analyzer.node(*self) {
             Node::FunctionParam(param) => param,
             e => panic!(
-                "Node type confusion: expected node to be FunctionParam but it was: {:?}",
-                e
+                "Node type confusion: expected node to be FunctionParam but it was: {e:?}"
             ),
         }
     }
@@ -490,7 +487,7 @@ impl AsDotStr for FunctionReturnNode {
             "{}{}{}",
             var_ty.as_dot_str(analyzer),
             if let Some(stor) = &self.underlying(analyzer).storage {
-                format!(" {} ", stor)
+                format!(" {stor} ")
             } else {
                 "".to_string()
             },
@@ -508,8 +505,7 @@ impl FunctionReturnNode {
         match analyzer.node(*self) {
             Node::FunctionReturn(ret) => ret,
             e => panic!(
-                "Node type confusion: expected node to be FunctionParam but it was: {:?}",
-                e
+                "Node type confusion: expected node to be FunctionParam but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/mod.rs
+++ b/shared/src/nodes/mod.rs
@@ -171,7 +171,11 @@ impl VarType {
         }
     }
 
-    pub fn try_literal_cast(self, other: &Self, analyzer: &mut (impl GraphLike + AnalyzerLike)) -> Option<Self> {
+    pub fn try_literal_cast(
+        self,
+        other: &Self,
+        analyzer: &mut (impl GraphLike + AnalyzerLike),
+    ) -> Option<Self> {
         match (self, other) {
             (Self::BuiltIn(from_bn, sr), Self::BuiltIn(to_bn, _)) => {
                 if from_bn.implicitly_castable_to(to_bn, analyzer) {
@@ -179,7 +183,7 @@ impl VarType {
                 } else {
                     None
                 }
-            },
+            }
             (Self::Concrete(from_c), Self::BuiltIn(to_bn, _)) => {
                 let c = from_c.underlying(analyzer).clone();
                 let b = to_bn.underlying(analyzer);

--- a/shared/src/nodes/mod.rs
+++ b/shared/src/nodes/mod.rs
@@ -281,8 +281,7 @@ impl VarType {
         match self {
             Self::BuiltIn(node, _) => node.array_underlying_ty(analyzer),
             e => panic!(
-                "Node type confusion: expected node to be VarType::Array but it was: {:?}",
-                e
+                "Node type confusion: expected node to be VarType::Array but it was: {e:?}"
             ),
         }
     }
@@ -358,8 +357,7 @@ impl BuiltInNode {
         match analyzer.node(*self) {
             Node::Builtin(b) => b,
             e => panic!(
-                "Node type confusion: expected node to be Builtin but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Builtin but it was: {e:?}"
             ),
         }
     }
@@ -391,8 +389,7 @@ impl BuiltInNode {
                 }),
             ),
             e => panic!(
-                "Node type confusion: expected node to be Builtin::Array but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Builtin::Array but it was: {e:?}"
             ),
         }
     }
@@ -537,9 +534,9 @@ impl Builtin {
             Payable => "payable".to_string(),
             Bool => "bool".to_string(),
             String => "string".to_string(),
-            Int(size) => format!("int{}", size),
-            Uint(size) => format!("uint{}", size),
-            Bytes(size) => format!("bytes{}", size),
+            Int(size) => format!("int{size}"),
+            Uint(size) => format!("uint{size}"),
+            Bytes(size) => format!("bytes{size}"),
             Rational => "rational".to_string(),
             DynamicBytes => "bytes".to_string(),
             Array(v_ty) => format!("{}[]", v_ty.as_string(analyzer)),

--- a/shared/src/nodes/mod.rs
+++ b/shared/src/nodes/mod.rs
@@ -280,9 +280,9 @@ impl VarType {
     pub fn array_underlying_ty(&self, analyzer: &mut impl AnalyzerLike) -> VarType {
         match self {
             Self::BuiltIn(node, _) => node.array_underlying_ty(analyzer),
-            e => panic!(
-                "Node type confusion: expected node to be VarType::Array but it was: {e:?}"
-            ),
+            e => {
+                panic!("Node type confusion: expected node to be VarType::Array but it was: {e:?}")
+            }
         }
     }
 
@@ -356,9 +356,7 @@ impl BuiltInNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Builtin {
         match analyzer.node(*self) {
             Node::Builtin(b) => b,
-            e => panic!(
-                "Node type confusion: expected node to be Builtin but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Builtin but it was: {e:?}"),
         }
     }
 
@@ -388,9 +386,9 @@ impl BuiltInNode {
                     exclusions: vec![],
                 }),
             ),
-            e => panic!(
-                "Node type confusion: expected node to be Builtin::Array but it was: {e:?}"
-            ),
+            e => {
+                panic!("Node type confusion: expected node to be Builtin::Array but it was: {e:?}")
+            }
         }
     }
 

--- a/shared/src/nodes/msg.rs
+++ b/shared/src/nodes/msg.rs
@@ -18,8 +18,7 @@ impl MsgNode {
         match analyzer.node(*self) {
             Node::Msg(st) => st,
             e => panic!(
-                "Node type confusion: expected node to be Msg but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Msg but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/msg.rs
+++ b/shared/src/nodes/msg.rs
@@ -17,9 +17,7 @@ impl MsgNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Msg {
         match analyzer.node(*self) {
             Node::Msg(st) => st,
-            e => panic!(
-                "Node type confusion: expected node to be Msg but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Msg but it was: {e:?}"),
         }
     }
 }

--- a/shared/src/nodes/struct_ty.rs
+++ b/shared/src/nodes/struct_ty.rs
@@ -15,9 +15,7 @@ impl StructNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Struct {
         match analyzer.node(*self) {
             Node::Struct(st) => st,
-            e => panic!(
-                "Node type confusion: expected node to be Struct but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Struct but it was: {e:?}"),
         }
     }
 
@@ -122,9 +120,7 @@ impl FieldNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Field {
         match analyzer.node(*self) {
             Node::Field(field) => field,
-            e => panic!(
-                "Node type confusion: expected node to be Field but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Field but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/struct_ty.rs
+++ b/shared/src/nodes/struct_ty.rs
@@ -16,8 +16,7 @@ impl StructNode {
         match analyzer.node(*self) {
             Node::Struct(st) => st,
             e => panic!(
-                "Node type confusion: expected node to be Struct but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Struct but it was: {e:?}"
             ),
         }
     }
@@ -124,8 +123,7 @@ impl FieldNode {
         match analyzer.node(*self) {
             Node::Field(field) => field,
             e => panic!(
-                "Node type confusion: expected node to be Field but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Field but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/ty_ty.rs
+++ b/shared/src/nodes/ty_ty.rs
@@ -12,8 +12,7 @@ impl TyNode {
         match analyzer.node(*self) {
             Node::Ty(ty) => ty,
             e => panic!(
-                "Node type confusion: expected node to be Ty but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Ty but it was: {e:?}"
             ),
         }
     }

--- a/shared/src/nodes/ty_ty.rs
+++ b/shared/src/nodes/ty_ty.rs
@@ -11,9 +11,7 @@ impl TyNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Ty {
         match analyzer.node(*self) {
             Node::Ty(ty) => ty,
-            e => panic!(
-                "Node type confusion: expected node to be Ty but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Ty but it was: {e:?}"),
         }
     }
 }

--- a/shared/src/nodes/var_ty.rs
+++ b/shared/src/nodes/var_ty.rs
@@ -15,9 +15,7 @@ impl VarNode {
     pub fn underlying<'a>(&self, analyzer: &'a impl GraphLike) -> &'a Var {
         match analyzer.node(*self) {
             Node::Var(func) => func,
-            e => panic!(
-                "Node type confusion: expected node to be Var but it was: {e:?}"
-            ),
+            e => panic!("Node type confusion: expected node to be Var but it was: {e:?}"),
         }
     }
 

--- a/shared/src/nodes/var_ty.rs
+++ b/shared/src/nodes/var_ty.rs
@@ -16,8 +16,7 @@ impl VarNode {
         match analyzer.node(*self) {
             Node::Var(func) => func,
             e => panic!(
-                "Node type confusion: expected node to be Var but it was: {:?}",
-                e
+                "Node type confusion: expected node to be Var but it was: {e:?}"
             ),
         }
     }
@@ -46,7 +45,7 @@ impl AsDotStr for VarNode {
                 .iter()
                 .map(|attr| {
                     match attr {
-                        VariableAttribute::Visibility(vis) => format!(" {}", vis),
+                        VariableAttribute::Visibility(vis) => format!(" {vis}"),
                         VariableAttribute::Constant(_) => " constant".to_string(),
                         VariableAttribute::Immutable(_) => " immutable".to_string(),
                         VariableAttribute::Override(_, _) => " override".to_string(),

--- a/shared/src/range/elem_ty.rs
+++ b/shared/src/range/elem_ty.rs
@@ -237,41 +237,37 @@ impl RangeElem<Concrete> for RangeConcrete<Concrete> {
     }
 
     fn range_ord(&self, other: &Self) -> Option<std::cmp::Ordering> {
-    	match (self.val.into_u256(), other.val.into_u256()) {
-    		(Some(self_val), Some(other_val)) => Some(self_val.cmp(&other_val)),
-    		(Some(_), _) => {
-    			match other.val {
-    				Concrete::Int(_, _) => {
-    					// if we couldnt convert an int to uint, its negative
-    					// so self must be > other
-    					Some(std::cmp::Ordering::Greater)
-    				}
-    				_ => None
-    			}
-    		}
-    		(_, Some(_)) => {
-    			match self.val {
-    				Concrete::Int(_, _) => {
-    					// if we couldnt convert an int to uint, its negative
-    					// so self must be < other
-    					Some(std::cmp::Ordering::Less)
-    				}
-    				_ => None
-    			}
-    		}
-    		_ => {
-    			match (&self.val, &other.val) {
-    				// two negatives
-    				(Concrete::Int(_, s), Concrete::Int(_, o)) => {
-    					Some(s.cmp(o))
-    				},
-    				(Concrete::DynBytes(b0), Concrete::DynBytes(b1)) => {
-    					Some(b0.cmp(b1))
-    				},
-    				_ => None
-    			}
-    		}
-    	}
+        match (self.val.into_u256(), other.val.into_u256()) {
+            (Some(self_val), Some(other_val)) => Some(self_val.cmp(&other_val)),
+            (Some(_), _) => {
+                match other.val {
+                    Concrete::Int(_, _) => {
+                        // if we couldnt convert an int to uint, its negative
+                        // so self must be > other
+                        Some(std::cmp::Ordering::Greater)
+                    }
+                    _ => None,
+                }
+            }
+            (_, Some(_)) => {
+                match self.val {
+                    Concrete::Int(_, _) => {
+                        // if we couldnt convert an int to uint, its negative
+                        // so self must be < other
+                        Some(std::cmp::Ordering::Less)
+                    }
+                    _ => None,
+                }
+            }
+            _ => {
+                match (&self.val, &other.val) {
+                    // two negatives
+                    (Concrete::Int(_, s), Concrete::Int(_, o)) => Some(s.cmp(o)),
+                    (Concrete::DynBytes(b0), Concrete::DynBytes(b1)) => Some(b0.cmp(b1)),
+                    _ => None,
+                }
+            }
+        }
     }
 
     fn dependent_on(&self) -> Vec<ContextVarNode> {

--- a/shared/src/range/elem_ty.rs
+++ b/shared/src/range/elem_ty.rs
@@ -59,7 +59,7 @@ impl RangeElem<Concrete> for Dynamic {
                 loc: cvar.loc.unwrap_or(Loc::Implicit),
             }),
             e => {
-                println!("dynamic {:?}", e);
+                println!("dynamic {e:?}");
                 Elem::Dynamic(*self)
             }
         }
@@ -80,7 +80,7 @@ impl RangeElem<Concrete> for Dynamic {
                 loc: cvar.loc.unwrap_or(Loc::Implicit),
             }),
             e => {
-                println!("dynamic {:?}", e);
+                println!("dynamic {e:?}");
                 Elem::Dynamic(*self)
             }
         }
@@ -508,7 +508,7 @@ impl RangeElem<Concrete> for Elem<Concrete> {
             (Self::Concrete(a), Self::Concrete(b)) => {
                 let ord = a.range_ord(b);
                 if ord.is_none() {
-                    println!("couldnt compare: {:?} {:?}", a, b);
+                    println!("couldnt compare: {a:?} {b:?}");
                 }
 
                 ord

--- a/shared/src/range/mod.rs
+++ b/shared/src/range/mod.rs
@@ -128,7 +128,7 @@ impl SolcRange {
                 })
             }
             e => {
-                println!("from: {:?}", e);
+                println!("from: {e:?}");
                 None
             }
         }

--- a/shared/src/range/range_string.rs
+++ b/shared/src/range/range_string.rs
@@ -161,7 +161,7 @@ impl ToRangeString for RangeDyn<Concrete> {
                 })
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!("{} ... {}", val_str_head, val_str_tail)
+            format!("{val_str_head} ... {val_str_tail}")
         } else {
             let displayed_vals = self
                 .val

--- a/src/builtin_fns.rs
+++ b/src/builtin_fns.rs
@@ -1,8 +1,6 @@
 use crate::Builtin;
 use crate::{AnalyzerLike, Function, FunctionParam, FunctionReturn};
-use solang_parser::pt::{
-    FunctionAttribute, Identifier, Loc, StorageLocation, Visibility,
-};
+use solang_parser::pt::{FunctionAttribute, Identifier, Loc, StorageLocation, Visibility};
 use std::collections::HashMap;
 
 macro_rules! builtin_fn {

--- a/src/context/exprs/member_access.rs
+++ b/src/context/exprs/member_access.rs
@@ -13,7 +13,7 @@ use shared::{
 use std::collections::BTreeSet;
 
 use ethers_core::types::{I256, U256};
-use petgraph::{visit::EdgeRef, Direction};
+
 use solang_parser::pt::{Expression, Identifier, Loc};
 
 impl<T> MemberAccess for T where T: AnalyzerLike<Expr = Expression> + Sized {}

--- a/src/context/exprs/member_access.rs
+++ b/src/context/exprs/member_access.rs
@@ -97,7 +97,13 @@ pub trait MemberAccess: AnalyzerLike<Expr = Expression> + Sized {
                     }
                 }
                 VarType::BuiltIn(bn, _) => {
-                    return self.builin_member_access(loc, ctx, *bn, ContextVarNode::from(member_idx).is_storage(self), ident);
+                    return self.builin_member_access(
+                        loc,
+                        ctx,
+                        *bn,
+                        ContextVarNode::from(member_idx).is_storage(self),
+                        ident,
+                    );
                 }
                 e => todo!("member access: {:?}, {:?}", e, ident),
             },
@@ -439,7 +445,13 @@ pub trait MemberAccess: AnalyzerLike<Expr = Expression> + Sized {
                 }
             }
             Node::Builtin(ref _b) => {
-                return self.builin_member_access(loc, ctx, BuiltInNode::from(member_idx), false, ident);
+                return self.builin_member_access(
+                    loc,
+                    ctx,
+                    BuiltInNode::from(member_idx),
+                    false,
+                    ident,
+                );
             }
             e => todo!("{:?}", e),
         }
@@ -452,11 +464,11 @@ pub trait MemberAccess: AnalyzerLike<Expr = Expression> + Sized {
         ctx: ContextNode,
         node: BuiltInNode,
         is_storage: bool,
-        ident: &Identifier
+        ident: &Identifier,
     ) -> ExprRet {
         if let Some(ret) = self.library_func_search(ctx, node.0.into(), ident) {
             ret
-         } else {
+        } else {
             match node.underlying(self).clone() {
                 Builtin::Address | Builtin::AddressPayable | Builtin::Payable => {
                     // TODO: handle address(x).call/delegatecall, etc

--- a/src/context/func.rs
+++ b/src/context/func.rs
@@ -76,7 +76,7 @@ pub trait FuncCaller: GraphLike + AnalyzerLike<Expr = Expression> + Sized {
                         inputs.extend(input_exprs.to_vec());
                         self.intrinsic_func_call(loc, &inputs, func_idx, ctx)
                     } else {
-                         self.func_call(
+                        self.func_call(
                             ctx,
                             *loc,
                             &inputs,
@@ -331,20 +331,21 @@ pub trait FuncCaller: GraphLike + AnalyzerLike<Expr = Expression> + Sized {
                             self.parse_ctx_expr(&input_exprs[0], ctx).expect_single(),
                         ),
                         "push" => {
-                            let (arr_ctx, arr) = self.parse_ctx_expr(&input_exprs[0], ctx).expect_single();
+                            let (arr_ctx, arr) =
+                                self.parse_ctx_expr(&input_exprs[0], ctx).expect_single();
                             let arr = ContextVarNode::from(arr).latest_version(self);
                             // get length
-                            let len = self.tmp_length(
-                                arr,
-                                arr_ctx,
-                                *loc,
-                            );
+                            let len = self.tmp_length(arr, arr_ctx, *loc);
 
                             println!("array: {:?}", arr.underlying(self));
 
                             let len_as_idx = len.as_tmp(*loc, ctx, self);
                             // set length as index
-                            let index = self.index_into_array_inner(*loc, ExprRet::Single((arr_ctx, arr.latest_version(self).into())), ExprRet::Single((arr_ctx, len_as_idx.latest_version(self).into())));
+                            let index = self.index_into_array_inner(
+                                *loc,
+                                ExprRet::Single((arr_ctx, arr.latest_version(self).into())),
+                                ExprRet::Single((arr_ctx, len_as_idx.latest_version(self).into())),
+                            );
                             // assign index to new_elem
                             let new_elem = self.parse_ctx_expr(&input_exprs[1], ctx);
                             self.match_assign_sides(*loc, &index, &new_elem)

--- a/src/context/func.rs
+++ b/src/context/func.rs
@@ -509,7 +509,7 @@ pub trait FuncCaller: GraphLike + AnalyzerLike<Expr = Expression> + Sized {
                         panic!("input has fork - need to flatten")
                     }
                 } else {
-                    panic!("Length mismatch: {:?} {:?}", inputs, params);
+                    panic!("Length mismatch: {inputs:?} {params:?}");
                 }
             }
             _ => todo!("here"),
@@ -871,7 +871,7 @@ pub trait FuncCaller: GraphLike + AnalyzerLike<Expr = Expression> + Sized {
                             })
                             .collect::<Vec<_>>()
                             .join(", ");
-                        let _ = write!(mod_name, "{}", args_str);
+                        let _ = write!(mod_name, "{args_str}");
                     }
                     let _ = write!(mod_name, "");
                     self.user_types()

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -625,7 +625,7 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
 
     fn parse_ctx_expr_inner(&mut self, expr: &Expression, ctx: ContextNode) -> ExprRet {
         use Expression::*;
-        println!("ctx: {}, {:?}", ctx.underlying(self).path, expr);
+        // println!("ctx: {}, {:?}", ctx.underlying(self).path, expr);
         match expr {
             // literals
             NumberLiteral(loc, int, exp, _unit) => self.number_literal(ctx, *loc, int, exp, false),

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -12,7 +12,7 @@ use solang_parser::pt::VariableDeclaration;
 use crate::VarType;
 use petgraph::{visit::EdgeRef, Direction};
 use shared::{analyzer::AnalyzerLike, nodes::*, range::elem::RangeOp, Edge, Node, NodeIdx};
-use solang_parser::pt::{Expression, Identifier, Loc, Statement};
+use solang_parser::pt::{Expression, Loc, Statement};
 
 pub mod func;
 use func::*;

--- a/src/context/mod.rs
+++ b/src/context/mod.rs
@@ -955,13 +955,11 @@ pub trait ContextBuilder: AnalyzerLike<Expr = Expression> + Sized + ExprParser {
         rhs_cvar: ContextVarNode,
         ctx: ContextNode,
     ) -> ExprRet {
-
         // println!("rhs_range: {:?}", rhs_cvar.range(self));
         let (new_lower_bound, new_upper_bound): (Elem<Concrete>, Elem<Concrete>) = (
             Elem::Dynamic(Dynamic::new(rhs_cvar.latest_version(self).into(), loc)),
             Elem::Dynamic(Dynamic::new(rhs_cvar.latest_version(self).into(), loc)),
         );
-
 
         let new_lhs = self.advance_var_in_ctx(lhs_cvar.latest_version(self), loc, ctx);
         if !lhs_cvar.ty_eq(&rhs_cvar, self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@ impl Analyzer {
             .map_err(|err| err.to_string())
             .expect("Remappings file not found");
 
-        println!("remappings file: {:?}", remappings_file);
+        println!("remappings file: {remappings_file:?}");
         self.remappings = remappings_file
             .lines()
             .map(|x| x.trim())
@@ -366,7 +366,7 @@ impl Analyzer {
                 let canonical = fs::canonicalize(&remapped).unwrap();
 
                 let sol = fs::read_to_string(&canonical).unwrap_or_else(|_| {
-                    panic!("Could not find file for dependency: {:?}", canonical)
+                    panic!("Could not find file for dependency: {canonical:?}")
                 });
                 self.file_no += 1;
                 let file_no = self.file_no;
@@ -406,7 +406,7 @@ impl Analyzer {
                 let canonical = fs::canonicalize(&remapped).unwrap();
 
                 let sol = fs::read_to_string(&canonical).unwrap_or_else(|_| {
-                    panic!("Could not find file for dependency: {:?}", canonical)
+                    panic!("Could not find file for dependency: {canonical:?}")
                 });
                 self.file_no += 1;
                 let file_no = self.file_no;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use shared::analyzer::*;
 use shared::nodes::*;
 use shared::{Edge, Node, NodeIdx};
 use solang_parser::pt::Import;
-use std::path::{Component, Path};
+use std::path::{Path};
 
 use solang_parser::pt::{
     ContractDefinition, ContractPart, EnumDefinition, ErrorDefinition, Expression,
@@ -379,7 +379,7 @@ impl Analyzer {
                 ));
                 inner_sources
             }
-            Import::Rename(import_path, elems, _) => {
+            Import::Rename(import_path, _elems, _) => {
                 let remapping = self
                     .remappings
                     .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,30 +682,3 @@ impl Analyzer {
         TyNode(self.add_node(ty).index())
     }
 }
-
-pub fn normalize_path(path: &Path) -> PathBuf {
-    let mut components = path.components().peekable();
-    let mut ret = if let Some(c @ Component::Prefix(..)) = components.peek().cloned() {
-        components.next();
-        PathBuf::from(c.as_os_str())
-    } else {
-        PathBuf::new()
-    };
-
-    for component in components {
-        match component {
-            Component::Prefix(..) => unreachable!(),
-            Component::RootDir => {
-                ret.push(component.as_os_str());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => {
-                ret.pop();
-            }
-            Component::Normal(c) => {
-                ret.push(c);
-            }
-        }
-    }
-    ret
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,22 +380,18 @@ impl Analyzer {
                 inner_sources
             }
             Import::Rename(import_path, elems, _) => {
-                println!(
-                    "import_path: {:?}, elems: {:?}, curr: {:?}",
-                    import_path,
-                    elems,
-                    std::env::current_dir()
-                );
-
                 let remapping = self
                     .remappings
                     .iter()
                     .find(|x| import_path.string.starts_with(&x.0));
 
                 let remapped = if let Some((name, path)) = remapping {
-                    self.root
-                        .join(path)
-                        .join(import_path.string.replacen(name, "", 1))
+                    self.root.join(path).join(
+                        import_path
+                            .string
+                            .replacen(name, "", 1)
+                            .trim_start_matches('/'),
+                    )
                 } else {
                     current_path
                         .parent()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -340,6 +340,8 @@ impl Analyzer {
     ) -> Vec<(Option<NodeIdx>, String, String, usize)> {
         match import {
             Import::Plain(import_path, loc) => {
+                println!("import_path: {:?}", import_path);
+
                 let remapping = self
                     .remappings
                     .clone()
@@ -356,11 +358,6 @@ impl Analyzer {
                         .unwrap()
                         .join(import_path.string.clone())
                 };
-
-                println!("loc: {:?}", loc);
-                println!("import_path: {:?}", import_path);
-                println!("path: {:?}", &current_path);
-                println!("remapped: {:?}", remapped);
 
                 let sol = fs::read_to_string(&remapped).unwrap_or_else(|_| {
                     panic!("Could not find file for dependency: {:?}", remapped)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@ use shared::analyzer::*;
 use shared::nodes::*;
 use shared::{Edge, Node, NodeIdx};
 use solang_parser::pt::Import;
-use std::path::{Path};
+use std::path::Path;
 
 use solang_parser::pt::{
     ContractDefinition, ContractPart, EnumDefinition, ErrorDefinition, Expression,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
-use std::path::{Component, Path};
 use ethers_core::types::U256;
 use shared::analyzer::*;
 use shared::nodes::*;
 use shared::{Edge, Node, NodeIdx};
 use solang_parser::pt::Import;
+use std::path::{Component, Path};
 
 use solang_parser::pt::{
     ContractDefinition, ContractPart, EnumDefinition, ErrorDefinition, Expression,
@@ -179,7 +179,10 @@ impl AnalyzerLike for Analyzer {
 
 impl Analyzer {
     pub fn set_remappings_and_root(&mut self, remappings_path: String) {
-        self.root = PathBuf::from(&remappings_path).parent().unwrap().to_path_buf();
+        self.root = PathBuf::from(&remappings_path)
+            .parent()
+            .unwrap()
+            .to_path_buf();
         let remappings_file = fs::read_to_string(remappings_path)
             .map_err(|err| err.to_string())
             .expect("Remappings file not found");
@@ -347,9 +350,12 @@ impl Analyzer {
                     .find(|x| import_path.string.starts_with(&x.0));
 
                 let remapped = if let Some((name, path)) = remapping {
-                    self.root
-                        .join(path)
-                        .join(import_path.string.replacen(name, "", 1).trim_start_matches('/'))
+                    self.root.join(path).join(
+                        import_path
+                            .string
+                            .replacen(name, "", 1)
+                            .trim_start_matches('/'),
+                    )
                 } else {
                     current_path
                         .parent()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,18 +346,16 @@ impl Analyzer {
 
                 let remapping = self
                     .remappings
-                    .clone()
-                    .into_iter()
+                    .iter()
                     .find(|x| import_path.string.starts_with(&x.name));
 
-                let remapped = if remapping.is_some() {
-                    let unwrapped = remapping.clone().unwrap();
-                    Remapping::into_relative(remapping.unwrap(), &self.root)
+                let remapped = if let Some(mappings) = remapping {
+                    Remapping::into_relative(mappings.clone(), &self.root)
                         .path
                         .relative()
-                        .join(&import_path.string.replacen(&unwrapped.name.clone(), "", 1))
+                        .join(import_path.string.replacen(&mappings.name, "", 1))
                 } else {
-                    PathBuf::from(current_path.clone())
+                    current_path
                         .parent()
                         .unwrap()
                         .join(import_path.string.clone())
@@ -388,18 +386,16 @@ impl Analyzer {
                 );
                 let remapping = self
                     .remappings
-                    .clone()
-                    .into_iter()
+                    .iter()
                     .find(|x| import_path.string.starts_with(&x.name));
 
-                let remapped = if remapping.is_some() {
-                    let unwrapped = remapping.clone().unwrap();
-                    Remapping::into_relative(remapping.unwrap(), &self.root)
+                let remapped = if let Some(mappings) = remapping {
+                    Remapping::into_relative(mappings.clone(), &self.root)
                         .path
                         .relative()
-                        .join(&import_path.string.replacen(&unwrapped.name.clone(), "", 1))
+                        .join(import_path.string.replacen(&mappings.name, "", 1))
                 } else {
-                    PathBuf::from(current_path.clone())
+                    current_path
                         .parent()
                         .unwrap()
                         .join(import_path.string.clone())

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,8 +1,8 @@
-use shared::NodeIdx;
-use std::path::PathBuf;
 use pyrometer::Analyzer;
 use shared::analyzer::Search;
+use shared::NodeIdx;
 use shared::{nodes::FunctionNode, Edge};
+use std::path::PathBuf;
 
 pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let mut analyzer = Analyzer::default();
@@ -11,7 +11,6 @@ pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let entry = maybe_entry.unwrap();
     no_ctx_killed(analyzer, entry);
 }
-
 
 pub fn remapping_assert_no_ctx_killed(path_str: String, remapping_file: String, sol: &str) {
     let mut analyzer = Analyzer::default();
@@ -36,4 +35,3 @@ pub fn no_ctx_killed(analyzer: Analyzer, entry: NodeIdx) {
         }
     }
 }
-

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,13 +1,28 @@
+use shared::NodeIdx;
+use std::path::PathBuf;
 use pyrometer::Analyzer;
 use shared::analyzer::Search;
 use shared::{nodes::FunctionNode, Edge};
 
 pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let mut analyzer = Analyzer::default();
-    let (maybe_entry, mut all_sources) = analyzer.parse(sol);
+    let (maybe_entry, mut all_sources) = analyzer.parse(sol, &PathBuf::from(path_str.clone()));
     all_sources.push((maybe_entry, path_str, sol.to_string(), 0));
     let entry = maybe_entry.unwrap();
+    no_ctx_killed(analyzer, entry);
+}
 
+
+pub fn remapping_assert_no_ctx_killed(path_str: String, remapping_file: String, sol: &str) {
+    let mut analyzer = Analyzer::default();
+    analyzer.set_remappings_and_root(remapping_file);
+    let (maybe_entry, mut all_sources) = analyzer.parse(sol, &PathBuf::from(path_str.clone()));
+    all_sources.push((maybe_entry, path_str, sol.to_string(), 0));
+    let entry = maybe_entry.unwrap();
+    no_ctx_killed(analyzer, entry);
+}
+
+pub fn no_ctx_killed(analyzer: Analyzer, entry: NodeIdx) {
     let funcs = analyzer.search_children(entry, &Edge::Func);
     for func in funcs.into_iter() {
         if let Some(ctx) = FunctionNode::from(func).maybe_body_ctx(&analyzer) {
@@ -21,3 +36,4 @@ pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
         }
     }
 }
+

--- a/tests/no_killed_ctxs.rs
+++ b/tests/no_killed_ctxs.rs
@@ -22,8 +22,8 @@ fn test_cast() {
 fn test_dyn_types() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let path_str = format!("{}/tests/test_data/dyn_types.sol", manifest_dir);
-	let sol = include_str!("./test_data/dyn_types.sol");
-	assert_no_ctx_killed(path_str, sol);
+    let sol = include_str!("./test_data/dyn_types.sol");
+    assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
@@ -93,7 +93,10 @@ fn test_using() {
 #[test]
 fn test_relative_import() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/relative_imports/relative_import.sol", manifest_dir);
+    let path_str = format!(
+        "{}/tests/test_data/relative_imports/relative_import.sol",
+        manifest_dir
+    );
     let sol = include_str!("./test_data/relative_imports/relative_import.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -103,5 +106,9 @@ fn test_remapping_import() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let path_str = format!("{}/tests/test_data/remapping_import.sol", manifest_dir);
     let sol = include_str!("./test_data/remapping_import.sol");
-    remapping_assert_no_ctx_killed(path_str, format!("{}/tests/test_data/remappings.txt", manifest_dir), sol);
+    remapping_assert_no_ctx_killed(
+        path_str,
+        format!("{}/tests/test_data/remappings.txt", manifest_dir),
+        sol,
+    );
 }

--- a/tests/no_killed_ctxs.rs
+++ b/tests/no_killed_ctxs.rs
@@ -93,9 +93,7 @@ fn test_using() {
 #[test]
 fn test_relative_import() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!(
-        "{manifest_dir}/tests/test_data/relative_imports/relative_import.sol"
-    );
+    let path_str = format!("{manifest_dir}/tests/test_data/relative_imports/relative_import.sol");
     let sol = include_str!("./test_data/relative_imports/relative_import.sol");
     assert_no_ctx_killed(path_str, sol);
 }

--- a/tests/no_killed_ctxs.rs
+++ b/tests/no_killed_ctxs.rs
@@ -5,7 +5,7 @@ use helpers::*;
 #[test]
 fn test_bitwise() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/bitwise.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/bitwise.sol");
     let sol = include_str!("./test_data/bitwise.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -13,7 +13,7 @@ fn test_bitwise() {
 #[test]
 fn test_cast() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/cast.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/cast.sol");
     let sol = include_str!("./test_data/cast.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -21,7 +21,7 @@ fn test_cast() {
 #[test]
 fn test_dyn_types() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/dyn_types.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/dyn_types.sol");
     let sol = include_str!("./test_data/dyn_types.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -29,7 +29,7 @@ fn test_dyn_types() {
 #[test]
 fn test_env() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/env.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/env.sol");
     let sol = include_str!("./test_data/env.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -37,7 +37,7 @@ fn test_env() {
 #[test]
 fn test_function_calls() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/function_calls.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/function_calls.sol");
     let sol = include_str!("./test_data/function_calls.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -45,7 +45,7 @@ fn test_function_calls() {
 #[test]
 fn test_logical() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/logical.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/logical.sol");
     let sol = include_str!("./test_data/logical.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -53,7 +53,7 @@ fn test_logical() {
 #[test]
 fn test_loops() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/loops.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/loops.sol");
     let sol = include_str!("./test_data/loops.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -61,7 +61,7 @@ fn test_loops() {
 #[test]
 fn test_math() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/math.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/math.sol");
     let sol = include_str!("./test_data/math.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -69,7 +69,7 @@ fn test_math() {
 #[test]
 fn test_modifier() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/modifier.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/modifier.sol");
     let sol = include_str!("./test_data/modifier.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -77,7 +77,7 @@ fn test_modifier() {
 #[test]
 fn test_require() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/require.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/require.sol");
     let sol = include_str!("./test_data/require.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -85,7 +85,7 @@ fn test_require() {
 #[test]
 fn test_using() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/using.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/using.sol");
     let sol = include_str!("./test_data/using.sol");
     assert_no_ctx_killed(path_str, sol);
 }
@@ -94,8 +94,7 @@ fn test_using() {
 fn test_relative_import() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let path_str = format!(
-        "{}/tests/test_data/relative_imports/relative_import.sol",
-        manifest_dir
+        "{manifest_dir}/tests/test_data/relative_imports/relative_import.sol"
     );
     let sol = include_str!("./test_data/relative_imports/relative_import.sol");
     assert_no_ctx_killed(path_str, sol);
@@ -104,11 +103,11 @@ fn test_relative_import() {
 #[test]
 fn test_remapping_import() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
-    let path_str = format!("{}/tests/test_data/remapping_import.sol", manifest_dir);
+    let path_str = format!("{manifest_dir}/tests/test_data/remapping_import.sol");
     let sol = include_str!("./test_data/remapping_import.sol");
     remapping_assert_no_ctx_killed(
         path_str,
-        format!("{}/tests/test_data/remappings.txt", manifest_dir),
+        format!("{manifest_dir}/tests/test_data/remappings.txt"),
         sol,
     );
 }

--- a/tests/no_killed_ctxs.rs
+++ b/tests/no_killed_ctxs.rs
@@ -1,79 +1,107 @@
+use std::env;
 mod helpers;
 use helpers::*;
 
 #[test]
 fn test_bitwise() {
-    let path_str = "./test_data/bitwise.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/bitwise.sol", manifest_dir);
     let sol = include_str!("./test_data/bitwise.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_cast() {
-    let path_str = "./test_data/cast.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/cast.sol", manifest_dir);
     let sol = include_str!("./test_data/cast.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_dyn_types() {
-    let path_str = "./test_data/dyn_types.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/dyn_types.sol", manifest_dir);
 	let sol = include_str!("./test_data/dyn_types.sol");
 	assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_env() {
-    let path_str = "./test_data/env.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/env.sol", manifest_dir);
     let sol = include_str!("./test_data/env.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_function_calls() {
-    let path_str = "./test_data/function_calls.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/function_calls.sol", manifest_dir);
     let sol = include_str!("./test_data/function_calls.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_logical() {
-    let path_str = "./test_data/logical.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/logical.sol", manifest_dir);
     let sol = include_str!("./test_data/logical.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_loops() {
-    let path_str = "./test_data/loops.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/loops.sol", manifest_dir);
     let sol = include_str!("./test_data/loops.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_math() {
-    let path_str = "./test_data/math.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/math.sol", manifest_dir);
     let sol = include_str!("./test_data/math.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_modifier() {
-    let path_str = "./test_data/modifier.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/modifier.sol", manifest_dir);
     let sol = include_str!("./test_data/modifier.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_require() {
-    let path_str = "./test_data/require.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/require.sol", manifest_dir);
     let sol = include_str!("./test_data/require.sol");
     assert_no_ctx_killed(path_str, sol);
 }
 
 #[test]
 fn test_using() {
-    let path_str = "./test_data/using.sol".to_string();
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/using.sol", manifest_dir);
     let sol = include_str!("./test_data/using.sol");
     assert_no_ctx_killed(path_str, sol);
+}
+
+#[test]
+fn test_relative_import() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/relative_imports/relative_import.sol", manifest_dir);
+    let sol = include_str!("./test_data/relative_imports/relative_import.sol");
+    assert_no_ctx_killed(path_str, sol);
+}
+
+#[test]
+fn test_remapping_import() {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let path_str = format!("{}/tests/test_data/remapping_import.sol", manifest_dir);
+    let sol = include_str!("./test_data/remapping_import.sol");
+    remapping_assert_no_ctx_killed(path_str, format!("{}/tests/test_data/remappings.txt", manifest_dir), sol);
 }

--- a/tests/test_data/relative_imports/relative_import.sol
+++ b/tests/test_data/relative_imports/relative_import.sol
@@ -1,0 +1,8 @@
+import "../env.sol";
+
+contract RelativeImport {
+	function deploy() public {
+		Env env = Env(address(100));
+		env.msg_sender();
+	}
+}

--- a/tests/test_data/remapping_import.sol
+++ b/tests/test_data/remapping_import.sol
@@ -1,0 +1,8 @@
+import "@relative/relative_import.sol";
+
+contract RemappingImport {
+	function deploy() public {
+		Env env = Env(address(100));
+		env.msg_sender();
+	}
+}

--- a/tests/test_data/remappings.txt
+++ b/tests/test_data/remappings.txt
@@ -1,0 +1,1 @@
+@relative=relative_imports/


### PR DESCRIPTION
Fixes #3 
Fixes #7

Hello, a Rust newbie here. I'm aiming to solve both previous issues but right now I'm getting unrelated errors testing against OpenZeppelin Contracts, mostly related to unsupported features such as assembly.

I'll make a better example and add it here for testing, but I'd appreciate comments.

## Usage

Relative imports should work out of the box, while remappings should be specified by:

```shell
pyrometer [OPTIONS] <PATH>

Arguments:
  <PATH>

Options:
  -r, --remappings <REMAPPINGS>
  ...
```

## Testing

I'm using the following setup for testing on a forge project:

```bash
src/
├── Counter.sol
└── Guarded.sol
lib/
└── openzeppelin-contracts/...
remappings.txt
```

running:

```bash
pyrometer ./src/Counter.sol --remappings ./remappings.txt
```

Where Counter.sol:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.15;

import "./Guarded.sol";

contract Counter is Guarded {
    uint256 public number;

    function setNumber(uint256 newNumber) public {
        number = newNumber;
    }

    function increment() public {
        number++;
    }
}
```

Guarded.sol:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.15;

import "@openzeppelin/contracts/security/ReentrancyGuard.sol";

contract Guarded is ReentrancyGuard {}
```
and remappings.txt:

```
ds-test/=lib/forge-std/lib/ds-test/src/
forge-std/=lib/forge-std/src/
@openzeppelin/=lib/openzeppelin-contracts/
```

- **Why reentrancy as an example?**: It's the only one that worked with the current Pyromenter support. Feel free to suggest a more complex alternative

### Output

```bash
Bounds: Bounds for function: function _nonReentrantBefore()
Bounds: Bounds for subcontext: _nonReentrantBefore() where:
  1. (_status != _ENTERED) == true

    ╭─[/Users/ernestognw/Documents/OpenZeppelin/contracts/lab/lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol:56:44]
    │
 56 │ ╭─▶     function _nonReentrantBefore() private {
    ┆ ┆
 62 │ ├─▶     }
    │ │
    │ ╰─────────── Entry function call
────╯
Bounds: Bounds for function: function _nonReentrantAfter()
Bounds: Bounds for subcontext: _nonReentrantAfter()
    ╭─[/Users/ernestognw/Documents/OpenZeppelin/contracts/lab/lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol:64:43]
    │
 64 │ ╭─▶     function _nonReentrantAfter() private {
    ┆ ┆
 68 │ ├─▶     }
    │ │
    │ ╰─────────── Entry function call
────╯
Bounds: Bounds for function: function _reentrancyGuardEntered()
Bounds: Bounds for subcontext: _reentrancyGuardEntered()
    ╭─[/Users/ernestognw/Documents/OpenZeppelin/contracts/lab/lib/openzeppelin-contracts/contracts/security/ReentrancyGuard.sol:74:69]
    │
 74 │ ╭─▶     function _reentrancyGuardEntered() internal view returns (bool) {
 75 │ │           return _status == _ENTERED;
    │ │           ─────────────┬────────────
    │ │                        ╰────────────── returns: "_status == _ENTERED" == true
 76 │ ├─▶     }
    │ │
    │ ╰─────────── Entry function call
────╯
Bounds: Bounds for function: function number()
Bounds: Bounds for subcontext: number()
   ╭─[./src/Counter.sol:7:5]
   │
 7 │     uint256 public number;
   │     ──────────┬──────────
   │               ╰──────────── Entry function call
   │               │
   │               ╰──────────── returns: "number" == 0
───╯
Bounds: Bounds for function: function setNumber(uint256)
Bounds: Bounds for subcontext: setNumber(uint256)
    ╭─[./src/Counter.sol:9:50]
    │
  9 │ ╭─▶     function setNumber(uint256 newNumber) public {
    ┆ ┆
 11 │ ├─▶     }
    │ │
    │ ╰─────────── Entry function call
────╯
Bounds: Bounds for function: function increment()
Bounds: Bounds for subcontext: increment()
    ╭─[./src/Counter.sol:13:33]
    │
 13 │ ╭─▶     function increment() public {
    ┆ ┆
 15 │ ├─▶     }
    │ │
    │ ╰─────────── Entry function call
────╯
```

## Note
I don't feel comfortable about how many dependencies `ethers_solc` is bringing in, so I'm fine removing it as long as someone points me to an alternative. 