### PR TITLE
fix: disambiguation

### DIFF
--- a/shared/src/nodes/mod.rs
+++ b/shared/src/nodes/mod.rs
@@ -68,6 +68,20 @@ impl VarType {
         }
     }
 
+    pub fn possible_builtins_from_ty_inf(&self, analyzer: &impl GraphLike) -> Vec<Builtin> {
+        match self {
+            Self::BuiltIn(bn, _) => bn
+                .underlying(analyzer)
+                .unwrap()
+                .possible_builtins_from_ty_inf(),
+            Self::Concrete(c) => c
+                .underlying(analyzer)
+                .unwrap()
+                .possible_builtins_from_ty_inf(),
+            _ => vec![],
+        }
+    }
+
     pub fn ty_idx(&self) -> NodeIdx {
         match self {
             Self::User(ty_node, _) => (*ty_node).into(),
@@ -872,6 +886,35 @@ impl Builtin {
             )),
             _ => Ok(self.clone()),
         }
+    }
+
+    pub fn possible_builtins_from_ty_inf(&self) -> Vec<Builtin> {
+        let mut builtins = vec![];
+        match self {
+            Builtin::Uint(size) => {
+                let mut s = *size;
+                while s > 0 {
+                    builtins.push(Builtin::Uint(s));
+                    s -= 8;
+                }
+            }
+            Builtin::Int(size) => {
+                let mut s = *size;
+                while s > 0 {
+                    builtins.push(Builtin::Int(s));
+                    s -= 8;
+                }
+            }
+            Builtin::Bytes(size) => {
+                let mut s = *size;
+                while s > 0 {
+                    builtins.push(Builtin::Bytes(s));
+                    s -= 1;
+                }
+            }
+            _ => {}
+        }
+        builtins
     }
 
     pub fn zero_range(&self) -> Option<SolcRange> {

--- a/src/context/func_call/internal_call.rs
+++ b/src/context/func_call/internal_call.rs
@@ -247,6 +247,12 @@ pub trait InternalFuncCaller:
                         match VarType::try_from_idx(analyzer, *idx) {
                             Some(VarType::BuiltIn(bn, _)) => {
                                 matches!(analyzer.node(bn), Node::Builtin(Builtin::Uint(_)) | Node::Builtin(Builtin::Int(_)) | Node::Builtin(Builtin::Bytes(_)))
+                                // match analyzer.node(bn) {
+                                //     Node::Builtin(Builtin::Uint(s)) if s < &256 => true,
+                                //     Node::Builtin(Builtin::Int(s)) if s < &256 => true,
+                                //     Node::Builtin(Builtin::Bytes(s)) if s < &32 => true,
+                                //     _ => false
+                                // }
                             }
                             Some(VarType::Concrete(c)) => {
                                 matches!(analyzer.node(c), Node::Concrete(Concrete::Uint(_, _)) | Node::Concrete(Concrete::Int(_, _)) | Node::Concrete(Concrete::Bytes(_, _)))

--- a/src/context/func_call/mod.rs
+++ b/src/context/func_call/mod.rs
@@ -147,9 +147,10 @@ pub trait FuncCaller:
                             if param_ty.ty_eq(input_ty, self).unwrap() {
                                 true
                             } else if literals[i] {
-                                let as_concrete =
-                                    ContextVarNode::from(*input).as_concrete(self).unwrap();
-                                let possibilities = as_concrete.possible_builtins_from_ty_inf();
+                                let possibilities = ContextVarNode::from(*input)
+                                    .ty(self)
+                                    .unwrap()
+                                    .possible_builtins_from_ty_inf(self);
                                 let param_ty = param.ty(self).unwrap();
                                 match self.node(param_ty) {
                                     Node::Builtin(b) => possibilities.contains(b),

--- a/tests/test_data/function_calls.sol
+++ b/tests/test_data/function_calls.sol
@@ -72,3 +72,14 @@ contract K {
         require(l.c == 3);
     }
 }
+
+
+contract Disambiguation {
+    function foo(address from, address to, uint256 id) public {
+        foo(from, to, id, 0);
+    }
+
+    function foo(address from, address to, uint256 id, uint num) internal {}
+
+    function foo(address by, address from, address to, uint256 id) internal {}
+}


### PR DESCRIPTION
Fixes disambiguation by not expecting the input to be a concrete, but could also be a builtin