### PR TITLE
feat: Add support for Solc Standard JSONs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 **/dot.dot
 **/flamegraph.svg
 **/.swp
+/.vscode
+.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,7 @@ dependencies = [
  "clap 4.2.1",
  "petgraph",
  "pyrometer",
+ "serde_json",
  "shared",
  "tracing",
  "tracing-subscriber",
@@ -540,9 +541,9 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.13.3"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cdacd4d6ed3f9b98680b679c0e52a823b8a2c7a97358d508fe247f2180c282"
+checksum = "968405c8fdc9b3bf4df0a6638858cc0b52462836ab6b1c87377785dd09cf1c0b"
 dependencies = [
  "base16ct",
  "crypto-bigint",
@@ -637,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "ethers-core"
-version = "2.0.2"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40bf114f1017ace0f622f1652f59c2c5e1abfe7d88891cca0c43da979b351de0"
+checksum = "6da5fa198af0d3be20c19192df2bd9590b92ce09a8421e793bec8851270f1b05"
 dependencies = [
  "arrayvec",
  "bytes",
@@ -647,7 +648,6 @@ dependencies = [
  "elliptic-curve",
  "ethabi",
  "generic-array",
- "getrandom",
  "hex",
  "k256",
  "num_enum",
@@ -724,10 +724,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -904,9 +902,9 @@ dependencies = [
 
 [[package]]
 name = "k256"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955890845095ccf31ef83ad41a05aabb4d8cc23dc3cac5a9f5c89cf26dd0da75"
+checksum = "cadb76004ed8e97623117f3df85b17aaa6626ab0b0831e6573f104df16cd1bcc"
 dependencies = [
  "cfg-if",
  "ecdsa",
@@ -1064,23 +1062,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "7a015b430d3c108a207fd776d2e2196aaf8b1cf8cf93253e3a097ff3085076a1"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "96667db765a921f7b295ffee8b60472b686a51d4f21c2ee4ffdb94c7013b65a6"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -1370,6 +1368,7 @@ dependencies = [
  "ethers-core",
  "hex",
  "petgraph",
+ "serde_json",
  "shared",
  "solang-parser",
  "tracing",
@@ -1898,15 +1897,15 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+checksum = "5a76a9312f5ba4c2dec6b9161fdf25d87ad8a09256ccea5a556fef03c706a10f"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2274,9 +2273,9 @@ checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winnow"
-version = "0.4.1"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+checksum = "61de7bac303dc551fe038e2b3cef0f571087a47571ea6e79a87692ac99b99699"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ shared = { path = "./shared" }
 hex = "0.4.3"
 tracing = { version = "0.1", features = ["attributes"] }
 tracing-subscriber = "0.3"
+serde_json = "1"
 
 [dev-dependencies]
 criterion = { version = "0.4"} # benching

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -75,5 +75,5 @@ fn bench(c: &mut Criterion) {
 fn parse(path: &PathBuf, sol: String) {
     let mut analyzer = Analyzer::default();
     let current_path = SourcePath::SolidityFile(path.clone());
-    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &current_path, true);
+    let _maybe_entry = analyzer.parse(&sol, &current_path, true);
 }

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,5 +1,5 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use pyrometer::Analyzer;
+use pyrometer::{Analyzer, SourcePath};
 use std::path::PathBuf;
 
 use std::env::{self};
@@ -73,9 +73,7 @@ fn bench(c: &mut Criterion) {
 /// * `path` - A `PathBuf` representing the path to the source code file.
 /// * `sol` - A string containing the Solidity source code.
 fn parse(path: &PathBuf, sol: String) {
-    let mut analyzer = Analyzer {
-        root: path.clone(),
-        ..Default::default()
-    };
-    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &path, true);
+    let mut analyzer = Analyzer::default();
+    let current_path = SourcePath::SolidityFile(path.clone());
+    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &current_path, true);
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ ariadne = "0.2.0"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry", "env-filter", "fmt"] }
 petgraph = "0.6.2"
+serde_json = "1"
 
 [[bin]]
 name = "pyrometer"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -202,11 +202,8 @@ fn main() {
             show_nonreverts: args.show_nonreverts.unwrap_or(true),
         },
     };
-    let root = Root::RemappingsDirectory(env::current_dir().unwrap());
-    let mut analyzer = Analyzer {
-        root: root,
-        ..Default::default()
-    };
+    let mut analyzer = Analyzer::default();
+    analyzer.root = Root::RemappingsDirectory(env::current_dir().unwrap());
 
     let (current_path, sol) = if args.path.ends_with(".sol") {
         let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
@@ -252,7 +249,6 @@ fn main() {
     }
     let mut source_map = sources(src_map);
 
-    // all_sources.push((maybe_entry, args.path, sol, 0));
     let entry = maybe_entry.unwrap();
 
     analyzer.print_errors(&file_mapping, &mut source_map);

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -208,14 +208,15 @@ fn main() {
         sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
         SourcePath::SolidityFile(&PathBuf::from(args.path.clone()))
     } else if args.path.ends_with(".json") {
+        // optimistically assume this is a Solc Standard JSON file from the compiler
         let json_value = serde_json::from_str::<serde_json::Value>(&args.path).unwrap();
-        // sol file will be the first value in the "sources" mapping
+        // main sol source will be the first value in the "sources" mapping
         let rel_path = json_value["sources"]
             .as_object()
-            .unwrap()
+            .expect("Could not find `sources` field in JSON file")
             .keys()
             .next()
-            .unwrap()
+            .expect("Could not find any sources in JSON file")
             .clone();
         sol = json_value["sources"][&rel_path]["content"];
         let fields_path = vec![

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,12 +1,11 @@
 use crate::analyzers::ReportConfig;
 use ariadne::sources;
 use clap::{ArgAction, Parser, ValueHint};
-use pyrometer::Root;
 use pyrometer::context::analyzers::FunctionVarsBoundAnalyzer;
+use pyrometer::Root;
 use pyrometer::{
     context::{analyzers::ReportDisplay, *},
-    Analyzer,
-    SourcePath,
+    Analyzer, SourcePath,
 };
 
 use shared::nodes::FunctionNode;
@@ -209,7 +208,6 @@ fn main() {
         ..Default::default()
     };
 
-
     let (current_path, sol) = if args.path.ends_with(".sol") {
         let sol = fs::read_to_string(args.path.clone()).expect("Could not find file");
         // Remappings file only required for Solidity files
@@ -218,20 +216,21 @@ fn main() {
             analyzer.set_remappings_and_root(remappings);
         }
 
-        (SourcePath::SolidityFile(PathBuf::from(args.path.clone())), sol)
+        (
+            SourcePath::SolidityFile(PathBuf::from(args.path.clone())),
+            sol,
+        )
     } else if args.path.ends_with(".json") {
         let json_path_buf = PathBuf::from(args.path.clone());
         analyzer.update_with_solc_json(&json_path_buf);
-        let (current_path, sol, _, _)  = analyzer.sources.iter().next().unwrap().clone();
+        let (current_path, sol, _, _) = analyzer.sources.iter().next().unwrap().clone();
         (current_path, sol)
     } else {
         panic!("Unsupported file type")
     };
 
-
     let t0 = std::time::Instant::now();
-    let maybe_entry =
-        analyzer.parse(&sol, &current_path, true);
+    let maybe_entry = analyzer.parse(&sol, &current_path, true);
     let parse_time = t0.elapsed().as_millis();
 
     println!("DONE ANALYZING IN: {parse_time}ms. Writing to cli...");
@@ -241,9 +240,15 @@ fn main() {
     let mut src_map: HashMap<String, String> = HashMap::new();
     for (source_path, sol, o_file_no, _o_entry) in analyzer.sources.iter() {
         if let Some(file_no) = o_file_no {
-            file_mapping.insert(*file_no, source_path.path_to_solidity_source().display().to_string());
+            file_mapping.insert(
+                *file_no,
+                source_path.path_to_solidity_source().display().to_string(),
+            );
         }
-        src_map.insert(source_path.path_to_solidity_source().display().to_string(), sol.to_string());
+        src_map.insert(
+            source_path.path_to_solidity_source().display().to_string(),
+            sol.to_string(),
+        );
     }
     let mut source_map = sources(src_map);
 

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -13,5 +13,5 @@ fn main() {
 
     let mut analyzer = Analyzer::default();
     let current_path = SourcePath::SolidityFile(comptroller_path.clone());
-    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &current_path, true);
+    let _maybe_entry = analyzer.parse(&sol, &current_path, true);
 }

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -10,7 +10,6 @@ fn main() {
 
     let sol = fs::read_to_string(comptroller_path).expect("Could not find file");
 
-
     let mut analyzer = Analyzer::default();
     let current_path = SourcePath::SolidityFile(comptroller_path.clone());
     let _maybe_entry = analyzer.parse(&sol, &current_path, true);

--- a/examples/parse.rs
+++ b/examples/parse.rs
@@ -1,4 +1,4 @@
-use pyrometer::Analyzer;
+use pyrometer::{Analyzer, SourcePath};
 use std::path::PathBuf;
 
 use std::fs;
@@ -10,9 +10,8 @@ fn main() {
 
     let sol = fs::read_to_string(comptroller_path).expect("Could not find file");
 
-    let mut analyzer = Analyzer {
-        root: bench_contracts_root.clone(),
-        ..Default::default()
-    };
-    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &bench_contracts_root, true);
+
+    let mut analyzer = Analyzer::default();
+    let current_path = SourcePath::SolidityFile(comptroller_path.clone());
+    let (_maybe_entry, mut _all_sources) = analyzer.parse(&sol, &current_path, true);
 }

--- a/shared/src/analyzer.rs
+++ b/shared/src/analyzer.rs
@@ -328,9 +328,7 @@ pub trait GraphLike {
                     skip.insert(*node);
                     return None;
                 }
-                let handled_nodes_contains = {
-                    handled_nodes.lock().unwrap().contains(node)
-                };
+                let handled_nodes_contains = { handled_nodes.lock().unwrap().contains(node) };
                 if !handled_nodes_contains {
                     match self.node(*node) {
                         Node::Function(_) => {
@@ -359,9 +357,7 @@ pub trait GraphLike {
         let edges_str = edges
             .into_iter()
             .filter_map(|edge| {
-                let handled_edges_contains = {
-                    handled_edges.lock().unwrap().contains(&edge)
-                };
+                let handled_edges_contains = { handled_edges.lock().unwrap().contains(&edge) };
                 if !handled_edges_contains {
                     let (from, to) = self.graph().edge_endpoints(edge).unwrap();
                     if skip.contains(&from) || skip.contains(&to) {

--- a/shared/src/analyzer.rs
+++ b/shared/src/analyzer.rs
@@ -184,6 +184,9 @@ pub trait GraphLike {
     ) {
         self.graph_mut()
             .add_edge(from_node.into(), to_node.into(), edge.into());
+        if petgraph::algo::is_cyclic_directed(self.graph()) {
+            panic!("Cyclic graph");
+        }
     }
 
     fn cluster_str(
@@ -325,7 +328,10 @@ pub trait GraphLike {
                     skip.insert(*node);
                     return None;
                 }
-                if !handled_nodes.lock().unwrap().contains(node) {
+                let handled_nodes_contains = {
+                    handled_nodes.lock().unwrap().contains(node)
+                };
+                if !handled_nodes_contains {
                     match self.node(*node) {
                         Node::Function(_) => {
                             cluster_num += 2;
@@ -353,7 +359,10 @@ pub trait GraphLike {
         let edges_str = edges
             .into_iter()
             .filter_map(|edge| {
-                if !handled_edges.lock().unwrap().contains(&edge) {
+                let handled_edges_contains = {
+                    handled_edges.lock().unwrap().contains(&edge)
+                };
+                if !handled_edges_contains {
                     let (from, to) = self.graph().edge_endpoints(edge).unwrap();
                     if skip.contains(&from) || skip.contains(&to) {
                         return None;

--- a/shared/src/nodes/contract_ty.rs
+++ b/shared/src/nodes/contract_ty.rs
@@ -228,7 +228,7 @@ impl Contract {
     pub fn from_w_imports(
         con: ContractDefinition,
         source: NodeIdx,
-        imports: &[(Option<NodeIdx>)],
+        imports: &[Option<NodeIdx>],
         analyzer: &impl GraphLike,
     ) -> (Contract, Vec<String>) {
         let mut inherits = vec![];

--- a/shared/src/nodes/contract_ty.rs
+++ b/shared/src/nodes/contract_ty.rs
@@ -228,7 +228,7 @@ impl Contract {
     pub fn from_w_imports(
         con: ContractDefinition,
         source: NodeIdx,
-        imports: &[(Option<NodeIdx>, String, String, usize)],
+        imports: &[(Option<NodeIdx>)],
         analyzer: &impl GraphLike,
     ) -> (Contract, Vec<String>) {
         let mut inherits = vec![];
@@ -249,7 +249,7 @@ impl Contract {
             }
 
             if !found {
-                for entry in imports.iter().filter_map(|import| import.0) {
+                for entry in imports.iter().filter_map(|&import| import) {
                     for contract in analyzer
                         .search_children_exclude_via(entry, &Edge::Contract, &[Edge::Func])
                         .into_iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,14 +500,10 @@ impl Analyzer {
         src: &str,
         current_path: &SourcePath,
         entry: bool,
-    ) -> (
-        Option<NodeIdx>,
-        Vec<(Option<NodeIdx>, String, String, usize)>,
-    ) {
+    ) -> Option<NodeIdx> {
         // tracing::trace!("parsing: {:?}", current_path);
         let file_no = self.file_no;
         self.sources.push((current_path.clone(), src.to_string(), Some(file_no), None));
-        let mut imported = vec![];
         match solang_parser::parse(src, file_no) {
             Ok((source_unit, _comments)) => {
                 let parent = self.add_node(Node::SourceUnit(file_no));
@@ -523,7 +519,7 @@ impl Analyzer {
                     self.final_pass();
                 }
 
-                (Some(parent), imported)
+                Some(parent)
             }
             Err(diagnostics) => {
                 print_diagnostics_report(src, &current_path.path_to_solidity_source(), diagnostics).unwrap();
@@ -864,7 +860,7 @@ impl Analyzer {
             *optional_file_no = Some(file_no);
         }
 
-        let (maybe_entry, mut inner_sources) = self.parse(&sol, &remapped, false);
+        let maybe_entry = self.parse(&sol, &remapped, false);
         
         // take self.sources entry with the same path as remapped and update the entry node
         if let Some((_, _, _, optional_entry)) = self.sources.iter_mut().find(|(path, _, _, _)| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -516,7 +516,6 @@ impl Analyzer {
                     source_unit,
                     file_no,
                     parent,
-                    &mut imported,
                     current_path,
                 );
                 self.final_pass_items.push(final_pass_part);
@@ -575,7 +574,6 @@ impl Analyzer {
         source_unit: SourceUnit,
         file_no: usize,
         parent: NodeIdx,
-        imported: &mut Vec<(Option<NodeIdx>, String, String, usize)>,
         current_path: &SourcePath,
     ) -> FinalPassItem {
         let mut all_funcs = vec![];
@@ -592,7 +590,6 @@ impl Analyzer {
                     file_no,
                     unit_part,
                     parent,
-                    imported,
                     current_path,
                 );
                 all_funcs.extend(funcs);
@@ -610,7 +607,7 @@ impl Analyzer {
         file_no: usize,
         unit_part: usize,
         parent: NodeIdx,
-        imported: &mut Vec<(Option<NodeIdx>, String, String, usize)>,
+        // imported: &mut Vec<(Option<NodeIdx>, String, String, usize)>,
         current_path: &SourcePath,
     ) -> (
         NodeIdx,
@@ -678,7 +675,7 @@ impl Analyzer {
             StraySemicolon(_loc) => todo!(),
             PragmaDirective(_, _, _) => {}
             ImportDirective(import) => {
-                imported.extend(self.parse_import(import, current_path, parent))
+                self.parse_import(import, current_path, parent);
             }
         }
         (sup_node, func_nodes, usings, inherits, vars)
@@ -690,7 +687,7 @@ impl Analyzer {
         import: &Import,
         current_path: &SourcePath,
         parent: NodeIdx,
-    ) -> Vec<(Option<NodeIdx>, String, String, usize)> {
+    ) {
         let (import_path, remapping) = match import {
             Import::Plain(import_path, _) => {
                 tracing::trace!("parse_import, path: {:?}", import_path);
@@ -878,15 +875,8 @@ impl Analyzer {
         
         if let Some(other_entry) = maybe_entry {
             self.add_edge(other_entry, parent, Edge::Import);
-        }
+        };
 
-        inner_sources.push((
-            maybe_entry,
-            remapped.path_to_solidity_source().to_string_lossy().to_string(),
-            sol.to_string(),
-            file_no,
-        ));
-        inner_sources
     }
 
     // #[tracing::instrument(name = "parse_contract_def", skip_all, fields(name = format!("{:?}", contract_def.name)))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,8 @@ impl Analyzer {
         self.root = Root::SolcJSON(path_to_json.clone());
 
         // iterate over the Solc JSON and add all the sources
-        let json_file = fs::read_to_string(path_to_json).expect(format!("Solc JSON file not found: {}", path_to_json.display()).as_str());
+        let json_file = fs::read_to_string(path_to_json)
+            .expect(format!("Solc JSON file not found: {}", path_to_json.display()).as_str());
         let solc_json: Value = serde_json::from_str(&json_file).unwrap();
         let sources = solc_json["sources"].as_object().unwrap();
         for (name, value_obj) in sources {
@@ -877,7 +878,6 @@ impl Analyzer {
                 .push((remapped.clone(), sol.clone(), None, None));
         }
 
-        
         let normalized_remapped = normalize_path(&remapped.path_to_solidity_source());
         // take self.sources entry with the same path as remapped and update the file_no
         if let Some((_, _, optional_file_no, _)) =

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -12,8 +12,7 @@ use std::path::PathBuf;
 pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let mut analyzer = Analyzer::default();
     let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
-    let maybe_entry =
-        analyzer.parse(sol, &current_path, true);
+    let maybe_entry = analyzer.parse(sol, &current_path, true);
     let entry = maybe_entry.unwrap();
     no_ctx_killed(analyzer, entry);
 }
@@ -22,16 +21,12 @@ pub fn remapping_assert_no_ctx_killed(path_str: String, remapping_file: String, 
     let mut analyzer = Analyzer::default();
     analyzer.set_remappings_and_root(remapping_file);
     let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
-    let maybe_entry =
-        analyzer.parse(sol, &current_path, true);
+    let maybe_entry = analyzer.parse(sol, &current_path, true);
     let entry = maybe_entry.unwrap();
     no_ctx_killed(analyzer, entry);
 }
 
-pub fn no_ctx_killed(
-    mut analyzer: Analyzer,
-    entry: NodeIdx,
-) {
+pub fn no_ctx_killed(mut analyzer: Analyzer, entry: NodeIdx) {
     assert!(
         analyzer.expr_errs.is_empty(),
         "Analyzer encountered parse errors"
@@ -53,12 +48,17 @@ pub fn no_ctx_killed(
     let mut src_map: HashMap<String, String> = HashMap::new();
     for (source_path, sol, o_file_no, _o_entry) in analyzer.sources.iter() {
         if let Some(file_no) = o_file_no {
-            file_mapping.insert(*file_no, source_path.path_to_solidity_source().display().to_string());
+            file_mapping.insert(
+                *file_no,
+                source_path.path_to_solidity_source().display().to_string(),
+            );
         }
-        src_map.insert(source_path.path_to_solidity_source().display().to_string(), sol.to_string());
+        src_map.insert(
+            source_path.path_to_solidity_source().display().to_string(),
+            sol.to_string(),
+        );
     }
     let mut source_map = sources(src_map);
-
 
     let funcs = analyzer.search_children(entry, &Edge::Func);
     for func in funcs.into_iter() {

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -1,7 +1,7 @@
 use ariadne::sources;
 use pyrometer::context::analyzers::ReportConfig;
 use pyrometer::context::analyzers::{FunctionVarsBoundAnalyzer, ReportDisplay};
-use pyrometer::Analyzer;
+use pyrometer::{Analyzer, SourcePath};
 use shared::analyzer::Search;
 use shared::NodeIdx;
 use shared::{nodes::FunctionNode, Edge};
@@ -11,8 +11,9 @@ use std::path::PathBuf;
 
 pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let mut analyzer = Analyzer::default();
+    let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
     let (maybe_entry, mut all_sources) =
-        analyzer.parse(sol, &PathBuf::from(path_str.clone()), true);
+        analyzer.parse(sol, &current_path, true);
     all_sources.push((maybe_entry, path_str.clone(), sol.to_string(), 0));
     let entry = maybe_entry.unwrap();
     no_ctx_killed(analyzer, entry, path_str, all_sources);
@@ -21,8 +22,9 @@ pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
 pub fn remapping_assert_no_ctx_killed(path_str: String, remapping_file: String, sol: &str) {
     let mut analyzer = Analyzer::default();
     analyzer.set_remappings_and_root(remapping_file);
+    let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
     let (maybe_entry, mut all_sources) =
-        analyzer.parse(sol, &PathBuf::from(path_str.clone()), true);
+        analyzer.parse(sol, &current_path, true);
     all_sources.push((maybe_entry, path_str.clone(), sol.to_string(), 0));
     let entry = maybe_entry.unwrap();
     no_ctx_killed(analyzer, entry, path_str, all_sources);

--- a/tests/helpers.rs
+++ b/tests/helpers.rs
@@ -12,29 +12,25 @@ use std::path::PathBuf;
 pub fn assert_no_ctx_killed(path_str: String, sol: &str) {
     let mut analyzer = Analyzer::default();
     let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
-    let (maybe_entry, mut all_sources) =
+    let maybe_entry =
         analyzer.parse(sol, &current_path, true);
-    all_sources.push((maybe_entry, path_str.clone(), sol.to_string(), 0));
     let entry = maybe_entry.unwrap();
-    no_ctx_killed(analyzer, entry, path_str, all_sources);
+    no_ctx_killed(analyzer, entry);
 }
 
 pub fn remapping_assert_no_ctx_killed(path_str: String, remapping_file: String, sol: &str) {
     let mut analyzer = Analyzer::default();
     analyzer.set_remappings_and_root(remapping_file);
     let current_path = SourcePath::SolidityFile(PathBuf::from(path_str.clone()));
-    let (maybe_entry, mut all_sources) =
+    let maybe_entry =
         analyzer.parse(sol, &current_path, true);
-    all_sources.push((maybe_entry, path_str.clone(), sol.to_string(), 0));
     let entry = maybe_entry.unwrap();
-    no_ctx_killed(analyzer, entry, path_str, all_sources);
+    no_ctx_killed(analyzer, entry);
 }
 
 pub fn no_ctx_killed(
     mut analyzer: Analyzer,
     entry: NodeIdx,
-    path_str: String,
-    all_sources: Vec<(Option<NodeIdx>, String, String, usize)>,
 ) {
     assert!(
         analyzer.expr_errs.is_empty(),
@@ -53,14 +49,16 @@ pub fn no_ctx_killed(
         show_unreachables: true,
         show_nonreverts: true,
     };
-    let file_mapping: BTreeMap<_, _> = vec![(0usize, path_str)].into_iter().collect();
+    let mut file_mapping: BTreeMap<usize, String> = BTreeMap::new();
+    let mut src_map: HashMap<String, String> = HashMap::new();
+    for (source_path, sol, o_file_no, _o_entry) in analyzer.sources.iter() {
+        if let Some(file_no) = o_file_no {
+            file_mapping.insert(*file_no, source_path.path_to_solidity_source().display().to_string());
+        }
+        src_map.insert(source_path.path_to_solidity_source().display().to_string(), sol.to_string());
+    }
+    let mut source_map = sources(src_map);
 
-    let mut source_map = sources(
-        all_sources
-            .iter()
-            .map(|(_entry, name, src, _num)| (name.clone(), src))
-            .collect::<HashMap<_, _>>(),
-    );
 
     let funcs = analyzer.search_children(entry, &Edge::Func);
     for func in funcs.into_iter() {


### PR DESCRIPTION
This required a refactor as atm Solidity sources are assumed to have unique filepaths, which are used for identification across HashMaps and BTreeMaps. Solc Standard JSONs fit each of the files into one .json, which would break this requirement.



Analyzer now has a `sources` field that is similar to the type of the `imported` v
```rust
/// Solidity sources - tuple of SourcePath, solidity string, file number (None until parsed), and entry node (None until parsed)
pub sources: Vec<(SourcePath, String, Option<usize>, Option<NodeIdx>,)>,
```

TODO:
- imports and remappings need more testing. Combinations of (sol/json, Some/None remapping)
- parse_import() used to have a `return vec![];` early return, now doesn't. Need to test why it was necessary. Maybe recursion breaking?
- clippy/lints

Draft - will update as I go.