### PR TITLE
fix: expression filter_recursion shouldn't arenaize

### DIFF
--- a/crates/graph/src/range/elem/expr/mod.rs
+++ b/crates/graph/src/range/elem/expr/mod.rs
@@ -384,7 +384,6 @@ impl RangeElem<Concrete> for RangeExpr<Concrete> {
         analyzer: &mut impl GraphBackend,
         arena: &mut RangeArena<Elem<Concrete>>,
     ) {
-        let _ = self.arenaize(analyzer, arena);
         self.lhs
             .filter_recursion(node_idx, new_idx, analyzer, arena);
         self.rhs


### PR DESCRIPTION
chatted on call about this.

prevents a cycle from forming in the arena on arrays when calling `create_length()`